### PR TITLE
fix: auto-register marketplaces referenced by plugins during pull

### DIFF
--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -126,9 +126,15 @@ func PullDryRun(claudeDir, syncDir string) (*PullResult, error) {
 		}
 	}
 
-	// Auto-register marketplaces referenced by plugins but not in config.yaml marketplaces section.
-	if _, regErr := marketplace.AutoRegisterFromPlugins(claudeDir, allDesired, cfg.Marketplaces); regErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: auto-registering marketplaces: %v\n", regErr)
+	// Auto-register marketplaces referenced by plugins but not in config.yaml.
+	// Best-effort: partial successes are fine since FindUndefinedMarketplaces
+	// (called next) catches anything not resolved.
+	// NOTE: Side effects (writes known_marketplaces.json, may clone repos)
+	// mirror the existing EnsureRegistered call above.
+	registered, regErr := marketplace.AutoRegisterFromPlugins(claudeDir, allDesired, cfg.Marketplaces)
+	if regErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: auto-registering marketplaces (registered %d): %v\n",
+			len(registered), regErr)
 	}
 
 	// Check for plugins referencing undefined marketplaces.

--- a/internal/marketplace/marketplace.go
+++ b/internal/marketplace/marketplace.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -445,6 +446,10 @@ func UpgradeDirectoryMarketplaces(claudeDir string) int {
 
 // detectGitHubRemote checks if dir is a git repo with a GitHub remote.
 // Returns "org/repo" if found, empty string otherwise.
+//
+// Silently returns "" on any failure (directory missing, not a git repo,
+// no origin remote, non-GitHub remote). Callers treat "" as "not a GitHub
+// repo" and fall back to directory-source registration.
 func detectGitHubRemote(dir string) string {
 	if _, err := os.Stat(dir); err != nil {
 		return ""
@@ -576,6 +581,13 @@ func FindUndefinedMarketplaces(claudeDir string, pluginKeys []string, declared m
 	return undefined
 }
 
+// dirEntry holds a marketplace name and its on-disk directory for batch
+// registration of directory-source marketplaces.
+type dirEntry struct {
+	name string
+	dir  string
+}
+
 // AutoRegisterFromPlugins scans plugin keys for marketplace references that are
 // not in the declared config.yaml marketplaces section and not yet registered in
 // known_marketplaces.json. For each such marketplace it attempts auto-registration:
@@ -585,13 +597,17 @@ func FindUndefinedMarketplaces(claudeDir string, pluginKeys []string, declared m
 //     marketplace.json are registered (as github if a GitHub remote is detected,
 //     otherwise as a directory source).
 //
-// Returns the names of successfully auto-registered marketplaces.
+// Marketplaces that don't match either strategy are silently skipped; callers
+// should use FindUndefinedMarketplaces afterward to surface truly unresolvable
+// references.
+//
+// Best-effort: partial successes are returned alongside a joined error. The
+// returned slice contains every marketplace that was successfully registered,
+// even when some registrations fail.
 func AutoRegisterFromPlugins(claudeDir string, pluginKeys []string, declared map[string]config.MarketplaceSource) ([]string, error) {
-	toRegister := make(map[string]config.MarketplaceSource)
-	var directoryRegistrations []struct {
-		name string
-		dir  string
-	}
+	githubToRegister := make(map[string]config.MarketplaceSource)
+	var directoryEntries []dirEntry
+	directorySeen := make(map[string]bool) // dedup directory entries
 
 	for _, key := range pluginKeys {
 		parts := strings.SplitN(key, "@", 2)
@@ -612,14 +628,18 @@ func AutoRegisterFromPlugins(claudeDir string, pluginKeys []string, declared map
 		if _, found := IsPortableFromKnownMarketplaces(claudeDir, mktName); found {
 			continue
 		}
-		// Skip if already queued.
-		if _, ok := toRegister[mktName]; ok {
+		// Skip if already queued for github registration.
+		if _, ok := githubToRegister[mktName]; ok {
+			continue
+		}
+		// Skip if already queued for directory registration.
+		if directorySeen[mktName] {
 			continue
 		}
 
 		// Strategy 1: Well-known marketplace — derive source from hardcoded map.
 		if org, ok := knownMarketplaces[mktName]; ok {
-			toRegister[mktName] = config.MarketplaceSource{
+			githubToRegister[mktName] = config.MarketplaceSource{
 				Source: "github",
 				Repo:   org + "/" + mktName,
 			}
@@ -629,76 +649,93 @@ func AutoRegisterFromPlugins(claudeDir string, pluginKeys []string, declared map
 		// Strategy 2: Directory exists on disk with valid marketplace.json.
 		mktDir := filepath.Join(claudeDir, "plugins", "marketplaces", mktName)
 		mkplPath := filepath.Join(mktDir, ".claude-plugin", "marketplace.json")
-		if _, err := os.Stat(mkplPath); err == nil {
-			if repo := detectGitHubRemote(mktDir); repo != "" {
-				toRegister[mktName] = config.MarketplaceSource{
-					Source: "github",
-					Repo:   repo,
-				}
-			} else {
-				directoryRegistrations = append(directoryRegistrations, struct {
-					name string
-					dir  string
-				}{mktName, mktDir})
-			}
+		info, err := os.Stat(mkplPath)
+		if err != nil || info.IsDir() {
 			continue
+		}
+		if repo := detectGitHubRemote(mktDir); repo != "" {
+			githubToRegister[mktName] = config.MarketplaceSource{
+				Source: "github",
+				Repo:   repo,
+			}
+		} else {
+			directoryEntries = append(directoryEntries, dirEntry{mktName, mktDir})
+			directorySeen[mktName] = true
 		}
 	}
 
 	var registered []string
+	var errs []error
 
-	// Register directory-source marketplaces directly.
-	for _, dr := range directoryRegistrations {
-		if err := registerDirectoryMarketplace(claudeDir, dr.name, dr.dir); err != nil {
-			return registered, fmt.Errorf("registering directory marketplace %q: %w", dr.name, err)
+	// Phase 1: Batch-register directory sources (single read-modify-write).
+	if len(directoryEntries) > 0 {
+		dirRegistered, dirErr := registerDirectoryMarketplaces(claudeDir, directoryEntries)
+		registered = append(registered, dirRegistered...)
+		if dirErr != nil {
+			errs = append(errs, dirErr)
 		}
-		registered = append(registered, dr.name)
 	}
 
-	// Use existing EnsureRegistered for github/git sources.
-	if len(toRegister) > 0 {
-		if err := EnsureRegistered(claudeDir, toRegister); err != nil {
-			return registered, err
-		}
-		for name := range toRegister {
-			registered = append(registered, name)
+	// Phase 2: Batch-register github/git sources via EnsureRegistered.
+	if len(githubToRegister) > 0 {
+		if err := EnsureRegistered(claudeDir, githubToRegister); err != nil {
+			errs = append(errs, err)
+		} else {
+			for name := range githubToRegister {
+				registered = append(registered, name)
+			}
 		}
 	}
 
 	sort.Strings(registered)
-	return registered, nil
+	return registered, errors.Join(errs...)
 }
 
-// registerDirectoryMarketplace registers a marketplace that already exists on
-// disk as a directory source in known_marketplaces.json.
-func registerDirectoryMarketplace(claudeDir, name, installDir string) error {
+// registerDirectoryMarketplaces batch-registers marketplaces that already exist
+// on disk as directory sources in known_marketplaces.json. Performs a single
+// read-modify-write cycle to avoid TOCTOU races. Returns the names of
+// successfully registered marketplaces and any error encountered.
+func registerDirectoryMarketplaces(claudeDir string, entries []dirEntry) ([]string, error) {
 	mkts, err := claudecode.ReadMarketplaces(claudeDir)
 	if err != nil {
 		if bErr := claudecode.Bootstrap(claudeDir); bErr != nil {
-			return fmt.Errorf("bootstrapping claude dir: %w", bErr)
+			return nil, fmt.Errorf("bootstrapping claude dir: %w", bErr)
 		}
 		mkts, err = claudecode.ReadMarketplaces(claudeDir)
 		if err != nil {
-			return fmt.Errorf("reading marketplaces after bootstrap: %w", err)
+			return nil, fmt.Errorf("reading marketplaces after bootstrap: %w", err)
 		}
 	}
-	if _, exists := mkts[name]; exists {
-		return nil
+
+	var registered []string
+	changed := false
+	for _, e := range entries {
+		if _, exists := mkts[e.name]; exists {
+			continue // idempotent: skip already-registered
+		}
+		entry := map[string]any{
+			"source": map[string]string{
+				"source": "directory",
+				"path":   e.dir,
+			},
+			"installLocation": e.dir,
+			"lastUpdated":     time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			continue
+		}
+		mkts[e.name] = json.RawMessage(raw)
+		registered = append(registered, e.name)
+		changed = true
 	}
-	entry := map[string]any{
-		"source": map[string]string{
-			"source": "directory",
-			"path":   installDir,
-		},
-		"installLocation": installDir,
-		"lastUpdated":     time.Now().UTC().Format(time.RFC3339Nano),
+
+	if changed {
+		if err := claudecode.WriteMarketplaces(claudeDir, mkts); err != nil {
+			return nil, fmt.Errorf("writing directory marketplaces: %w", err)
+		}
 	}
-	raw, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-	mkts[name] = json.RawMessage(raw)
-	return claudecode.WriteMarketplaces(claudeDir, mkts)
+	return registered, nil
 }
 
 // EnsureRegistered checks if each declared marketplace exists in

--- a/internal/marketplace/marketplace_test.go
+++ b/internal/marketplace/marketplace_test.go
@@ -1286,6 +1286,139 @@ func TestAutoRegisterFromPlugins_MixedScenarios(t *testing.T) {
 	assert.Len(t, registered, 2)
 }
 
+func TestAutoRegisterFromPlugins_BootstrapFallback(t *testing.T) {
+	// No plugins/ directory or known_marketplaces.json — triggers Bootstrap path.
+	claudeDir := t.TempDir()
+	// Pre-create install dir so clone is skipped.
+	require.NoError(t, os.MkdirAll(filepath.Join(claudeDir, "plugins", "marketplaces", "superpowers-marketplace"), 0755))
+
+	keys := []string{"my-plugin@superpowers-marketplace"}
+	registered, err := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+	require.NoError(t, err)
+	assert.Contains(t, registered, "superpowers-marketplace")
+
+	// Verify known_marketplaces.json was created (bootstrapped).
+	_, statErr := os.Stat(filepath.Join(claudeDir, "plugins", "known_marketplaces.json"))
+	assert.NoError(t, statErr, "known_marketplaces.json should be bootstrapped")
+}
+
+func TestAutoRegisterFromPlugins_ErrorPropagation(t *testing.T) {
+	// EnsureRegistered will fail because the github source can't be cloned.
+	// Directory registration should still succeed and be returned.
+	claudeDir := t.TempDir()
+	pluginDir := filepath.Join(claudeDir, "plugins")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "known_marketplaces.json"), []byte("{}"), 0644))
+
+	// Create an on-disk marketplace directory for directory registration.
+	mktDir := filepath.Join(pluginDir, "marketplaces", "dir-marketplace")
+	mkplDir := filepath.Join(mktDir, ".claude-plugin")
+	require.NoError(t, os.MkdirAll(mkplDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mkplDir, "marketplace.json"),
+		[]byte(`{"name": "dir-marketplace", "plugins": [{"name": "foo", "source": "./"}]}`), 0644))
+
+	// Don't pre-create the install dir for beads-marketplace — the clone will fail
+	// since we can't reach github.com/anthropics/beads-marketplace.
+	keys := []string{
+		"foo@dir-marketplace",
+		"bar@beads-marketplace",
+	}
+
+	registered, err := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+
+	// Directory marketplace should succeed even though github clone fails.
+	assert.Contains(t, registered, "dir-marketplace")
+	// Error should be non-nil because github clone failed.
+	assert.Error(t, err, "should propagate EnsureRegistered clone error")
+}
+
+func TestAutoRegisterFromPlugins_Idempotent(t *testing.T) {
+	claudeDir := t.TempDir()
+	pluginDir := filepath.Join(claudeDir, "plugins")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "known_marketplaces.json"), []byte("{}"), 0644))
+
+	// Create on-disk marketplace directory.
+	mktDir := filepath.Join(pluginDir, "marketplaces", "idem-mkt")
+	mkplDir := filepath.Join(mktDir, ".claude-plugin")
+	require.NoError(t, os.MkdirAll(mkplDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mkplDir, "marketplace.json"),
+		[]byte(`{"name": "idem-mkt", "plugins": [{"name": "p", "source": "./"}]}`), 0644))
+
+	keys := []string{"p@idem-mkt"}
+
+	// First call registers it.
+	reg1, err1 := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+	require.NoError(t, err1)
+	assert.Contains(t, reg1, "idem-mkt")
+
+	// Second call is a no-op — already registered.
+	reg2, err2 := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+	require.NoError(t, err2)
+	assert.Empty(t, reg2, "second call should be a no-op")
+}
+
+func TestAutoRegisterFromPlugins_DeduplicatesMarketplace(t *testing.T) {
+	claudeDir := t.TempDir()
+	pluginDir := filepath.Join(claudeDir, "plugins")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "known_marketplaces.json"), []byte("{}"), 0644))
+
+	// Create on-disk marketplace directory.
+	mktDir := filepath.Join(pluginDir, "marketplaces", "shared-mkt")
+	mkplDir := filepath.Join(mktDir, ".claude-plugin")
+	require.NoError(t, os.MkdirAll(mkplDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mkplDir, "marketplace.json"),
+		[]byte(`{"name": "shared-mkt", "plugins": [{"name": "a", "source": "./"}, {"name": "b", "source": "./"}]}`), 0644))
+
+	// Multiple plugins reference the same marketplace.
+	keys := []string{"a@shared-mkt", "b@shared-mkt", "c@shared-mkt"}
+
+	registered, err := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared-mkt"}, registered, "marketplace should only appear once")
+}
+
+func TestAutoRegisterFromPlugins_DirectoryEntryFormat(t *testing.T) {
+	claudeDir := t.TempDir()
+	pluginDir := filepath.Join(claudeDir, "plugins")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "known_marketplaces.json"), []byte("{}"), 0644))
+
+	// Create marketplace directory.
+	mktDir := filepath.Join(pluginDir, "marketplaces", "fmt-check-mkt")
+	mkplDir := filepath.Join(mktDir, ".claude-plugin")
+	require.NoError(t, os.MkdirAll(mkplDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mkplDir, "marketplace.json"),
+		[]byte(`{"name": "fmt-check-mkt", "plugins": [{"name": "x", "source": "./"}]}`), 0644))
+
+	keys := []string{"x@fmt-check-mkt"}
+	_, err := marketplace.AutoRegisterFromPlugins(claudeDir, keys, nil)
+	require.NoError(t, err)
+
+	// Read the JSON entry and verify structure.
+	data, err := os.ReadFile(filepath.Join(pluginDir, "known_marketplaces.json"))
+	require.NoError(t, err)
+
+	var entries map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &entries))
+	require.Contains(t, entries, "fmt-check-mkt")
+
+	var entry struct {
+		Source struct {
+			Source string `json:"source"`
+			Path   string `json:"path"`
+		} `json:"source"`
+		InstallLocation string `json:"installLocation"`
+		LastUpdated     string `json:"lastUpdated"`
+	}
+	require.NoError(t, json.Unmarshal(entries["fmt-check-mkt"], &entry))
+	assert.Equal(t, "directory", entry.Source.Source, "source.source should be 'directory'")
+	assert.Equal(t, mktDir, entry.Source.Path, "source.path should match install dir")
+	assert.Equal(t, mktDir, entry.InstallLocation, "installLocation should match dir")
+	assert.NotEmpty(t, entry.LastUpdated, "lastUpdated must be present for Claude Code Zod validation")
+}
+
 // ─── QueryRemoteVersion (skipped by default — requires network) ────────────
 
 func TestQueryRemoteVersion_InvalidURL(t *testing.T) {


### PR DESCRIPTION
# User description
## Summary
- Adds `AutoRegisterFromPlugins()` to scan plugin keys for marketplace references not in the `marketplaces` config section
- Well-known marketplaces (hardcoded list) are auto-registered as github sources with correct org/repo
- Marketplace directories already on disk with valid `marketplace.json` are auto-registered as directory sources (or github if a remote is detected)
- Called in `PullDryRun()` before `FindUndefinedMarketplaces()`, so only truly unresolvable marketplaces are reported as undefined

## Test plan
- [x] 9 new unit tests covering all scenarios: well-known, directory-on-disk, directory-with-github-remote, already-registered, already-declared, forks skipped, unknown-not-on-disk, empty input, mixed scenarios
- [x] All existing marketplace tests pass
- [x] All existing commands tests pass

Closes #9

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce auto-registration into PullDryRun so <code>AutoRegisterFromPlugins</code> resolves plugin-referenced marketplaces before undefined checks, keeping only truly missing marketplaces as errors. Implement <code>AutoRegisterFromPlugins</code>/<code>registerDirectoryMarketplaces</code> to derive sources from well-known names or on-disk dirs (detecting GitHub remotes) and cover all scenarios with new unit tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/14?tool=ast&topic=Pull+auto-register>Pull auto-register</a>
        </td><td>Hook PullDryRun into marketplace auto-registration by calling <code>AutoRegisterFromPlugins</code> before undefined checks so plugin-referenced marketplaces are resolved and only really missing entries are reported.<details><summary>Modified files (1)</summary><ul><li>internal/commands/pull.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-prevent-pull-from-...</td><td>March 03, 2026</td></tr>
<tr><td>albertgwo</td><td>feat-plugin-source-lif...</td><td>March 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/14?tool=ast&topic=Marketplace+registration>Marketplace registration</a>
        </td><td>Implement <code>AutoRegisterFromPlugins</code> plus <code>registerDirectoryMarketplaces</code> to detect unregistered marketplaces from plugin keys, register hardcoded GitHub sources or existing directories (upgrading to GitHub when remotes exist), and validate the behaviour through extensive tests.<details><summary>Modified files (2)</summary><ul><li>internal/marketplace/marketplace.go</li>
<li>internal/marketplace/marketplace_test.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-warn-when-plugins-...</td><td>February 28, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/ruminaider/claude-sync/14?tool=ast>(Baz)</a>.