### PR TITLE
fix: clear error when config.yaml missing during join

### DIFF
--- a/cmd/claude-sync/cmd_join.go
+++ b/cmd/claude-sync/cmd_join.go
@@ -103,7 +103,7 @@ var configJoinCmd = &cobra.Command{
 		}
 		var missingCfgErr *commands.MissingConfigError
 		if errors.As(err, &missingCfgErr) {
-			fmt.Println("✓ Cloned config repo to ~/.claude-sync/")
+			fmt.Printf("✓ Cloned config repo to %s\n", syncDir)
 			fmt.Println()
 			fmt.Println("Config repo has no config.yaml yet.")
 			fmt.Println("Run 'claude-sync init' to initialize it with your current setup.")
@@ -113,7 +113,7 @@ var configJoinCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println("✓ Cloned config repo to ~/.claude-sync/")
+		fmt.Printf("✓ Cloned config repo to %s\n", syncDir)
 
 		// Show what the config contains.
 		if result.HasSettings {

--- a/internal/commands/join.go
+++ b/internal/commands/join.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,7 +96,7 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 
 	cfg, err := config.Parse(cfgData)
 	if err != nil {
-		return result, nil
+		return nil, fmt.Errorf("parsing config.yaml: %w", err)
 	}
 
 	// Expose config categories so the CLI can prompt about them.
@@ -114,7 +115,10 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 		sort.Strings(result.HookNames)
 	}
 
-	profileNames, _ := profiles.ListProfiles(syncDir)
+	profileNames, err := profiles.ListProfiles(syncDir)
+	if err != nil {
+		return nil, fmt.Errorf("listing profiles: %w", err)
+	}
 	if len(profileNames) > 0 {
 		result.HasProfiles = true
 		result.ProfileNames = profileNames
@@ -122,7 +126,10 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 
 	installed, err := claudecode.ReadInstalledPlugins(claudeDir)
 	if err != nil {
-		return result, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return result, nil // No plugins file yet (fresh install) — skip detection
+		}
+		return nil, fmt.Errorf("detecting local plugins: %w", err)
 	}
 
 	configKeys := make(map[string]bool)
@@ -145,7 +152,9 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 
 // JoinReplace removes the existing sync dir and performs a fresh join.
 func JoinReplace(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
-	os.RemoveAll(syncDir)
+	if err := os.RemoveAll(syncDir); err != nil {
+		return nil, fmt.Errorf("removing existing config: %w", err)
+	}
 	return Join(repoURL, claudeDir, syncDir)
 }
 

--- a/internal/commands/join_test.go
+++ b/internal/commands/join_test.go
@@ -2,6 +2,7 @@ package commands_test
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -308,18 +309,19 @@ func TestJoin_EmptyLocalInstallation(t *testing.T) {
 func TestJoin_MissingConfigYaml(t *testing.T) {
 	// Create a remote repo with NO config.yaml.
 	remote := t.TempDir()
-	exec.Command("git", "init", remote).Run()
-	exec.Command("git", "-C", remote, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", remote, "config", "user.name", "Test").Run()
+	require.NoError(t, exec.Command("git", "init", remote).Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "config", "user.email", "test@test.com").Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "config", "user.name", "Test").Run())
 	os.WriteFile(filepath.Join(remote, "README.md"), []byte("# readme\n"), 0644)
-	exec.Command("git", "-C", remote, "add", ".").Run()
-	exec.Command("git", "-C", remote, "commit", "-m", "init without config").Run()
+	require.NoError(t, exec.Command("git", "-C", remote, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "commit", "-m", "init without config").Run())
 
 	claudeDir := setupLocalClaude(t, []string{})
 	syncDir := filepath.Join(t.TempDir(), ".claude-sync")
 
-	_, err := commands.Join(remote, claudeDir, syncDir)
+	result, err := commands.Join(remote, claudeDir, syncDir)
 	require.Error(t, err)
+	assert.Nil(t, result)
 
 	var missingErr *commands.MissingConfigError
 	assert.ErrorAs(t, err, &missingErr)
@@ -327,6 +329,47 @@ func TestJoin_MissingConfigYaml(t *testing.T) {
 	// Sync dir should still exist (clone succeeded).
 	_, statErr := os.Stat(syncDir)
 	assert.NoError(t, statErr)
+}
+
+func TestJoin_CorruptConfigYaml(t *testing.T) {
+	// Create a remote repo with invalid YAML as config.yaml.
+	remote := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", remote).Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "config", "user.email", "test@test.com").Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "config", "user.name", "Test").Run())
+	os.WriteFile(filepath.Join(remote, "config.yaml"), []byte("{{{{not valid yaml!!!!"), 0644)
+	require.NoError(t, exec.Command("git", "-C", remote, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", remote, "commit", "-m", "corrupt config").Run())
+
+	claudeDir := setupLocalClaude(t, []string{})
+	syncDir := filepath.Join(t.TempDir(), ".claude-sync")
+
+	result, err := commands.Join(remote, claudeDir, syncDir)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "parsing config.yaml")
+
+	// Should NOT be a MissingConfigError.
+	var missingErr *commands.MissingConfigError
+	assert.False(t, errors.As(err, &missingErr))
+}
+
+func TestJoin_UnreadableInstalledPlugins(t *testing.T) {
+	// Create a valid remote repo.
+	remote := setupRemoteRepo(t, []string{"context7@claude-plugins-official"})
+	claudeDir := setupLocalClaude(t, []string{})
+
+	// Replace installed_plugins.json with a directory to trigger a non-NotExist read error.
+	pluginsFile := filepath.Join(claudeDir, "plugins", "installed_plugins.json")
+	os.Remove(pluginsFile)
+	os.MkdirAll(pluginsFile, 0755)
+
+	syncDir := filepath.Join(t.TempDir(), ".claude-sync")
+
+	result, err := commands.Join(remote, claudeDir, syncDir)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "detecting local plugins")
 }
 
 func TestJoinReplace(t *testing.T) {


### PR DESCRIPTION
# User description
## Summary

- When `claude-sync config join` clones a repo with no `config.yaml`, the user now sees a clear, actionable message instead of a confusing `pull failed: reading config.yaml` error
- Added `MissingConfigError` type to `Join()` for proper error classification
- CLI catches this error and suggests running `claude-sync init` to initialize the config

## Changes

**`internal/commands/join.go`**: Added `MissingConfigError` type. `Join()` now returns this error when `config.yaml` is not found (instead of silently returning an empty result).

**`cmd/claude-sync/cmd_join.go`**: Added handler for `MissingConfigError` that displays a helpful message guiding the user to run `claude-sync init`.

**`internal/commands/join_test.go`**: Added `TestJoin_MissingConfigYaml` verifying the error type and that the sync dir persists after the clone.

## Test plan

- [x] New test `TestJoin_MissingConfigYaml` passes
- [x] All existing join tests pass (no regressions)
- [x] Full `go test ./...` passes

Fixes #4

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the <code>Join</code> flow by returning a <code>MissingConfigError</code> when no <code>config.yaml</code> exists and by surfacing other IO issues instead of silently swallowing them, while also covering the scenario with a regression test. Highlight the CLI join output so it reports a clean clone and prompts users to run <code>claude-sync init</code> when the repo has no configuration yet.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/15?tool=ast&topic=Join+validation>Join validation</a>
        </td><td>Improve <code>Join</code> validation to classify a missing <code>config.yaml</code>, wrap remaining filesystem errors, and cover the regression with a test that asserts the sync dir persists after cloning.<details><summary>Modified files (2)</summary><ul><li>internal/commands/join.go</li>
<li>internal/commands/join_test.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-route-join-to-subs...</td><td>February 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/15?tool=ast&topic=Join+CLI+UX>Join CLI UX</a>
        </td><td>Guide CLI join to print a successful clone message and explicitly tell users to run <code>claude-sync init</code> when the repo lacks <code>config.yaml</code>, while keeping the regular messaging path intact.<details><summary>Modified files (1)</summary><ul><li>cmd/claude-sync/cmd_join.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-route-join-to-subs...</td><td>February 28, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/ruminaider/claude-sync/15?tool=ast>(Baz)</a>.