### PR TITLE
fix: resolve upstream URL when joining from local non-bare checkout

### DIFF
--- a/internal/commands/join.go
+++ b/internal/commands/join.go
@@ -75,11 +75,13 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 		return nil, fmt.Errorf("cloning config repo: %w", err)
 	}
 
-	// If we cloned from a local path, resolve through to the real upstream
-	// remote to avoid push failures against non-bare local checkouts.
+	// If we cloned from a local path, look up that repo's origin remote
+	// so we push to the real upstream instead of the non-bare local checkout.
 	if git.IsLocalPath(repoURL) {
 		if upstream, err := git.ResolveUpstreamURL(repoURL); err == nil && upstream != "" {
-			git.SetRemoteURL(syncDir, "origin", upstream)
+			if err := git.SetRemoteURL(syncDir, "origin", upstream); err != nil {
+				return nil, fmt.Errorf("rewriting remote to upstream URL %q: %w", upstream, err)
+			}
 		}
 	}
 

--- a/internal/commands/join_test.go
+++ b/internal/commands/join_test.go
@@ -326,16 +326,23 @@ func TestJoinReplace(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// mustExec runs a command and fails the test if it errors.
+func mustExec(t *testing.T, name string, args ...string) {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	require.NoError(t, err, "%s %v failed: %s", name, args, string(out))
+}
+
 func TestJoin_LocalPath_ResolvesUpstream(t *testing.T) {
-	// Create a "real upstream" repo simulating a GitHub remote.
+	// Create a bare repo to act as the true upstream (analogous to a GitHub remote).
 	upstream := t.TempDir()
-	exec.Command("git", "init", "--bare", upstream).Run()
+	mustExec(t, "git", "init", "--bare", "-b", "main", upstream)
 
 	// Create a local non-bare checkout that has upstream as its origin.
 	local := t.TempDir()
-	exec.Command("git", "clone", upstream, local).Run()
-	exec.Command("git", "-C", local, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", local, "config", "user.name", "Test").Run()
+	mustExec(t, "git", "clone", upstream, local)
+	mustExec(t, "git", "-C", local, "config", "user.email", "test@test.com")
+	mustExec(t, "git", "-C", local, "config", "user.name", "Test")
 
 	cfg := config.Config{
 		Version:  "1.0.0",
@@ -345,9 +352,9 @@ func TestJoin_LocalPath_ResolvesUpstream(t *testing.T) {
 	cfgData, err := config.MarshalV2(cfg)
 	require.NoError(t, err)
 	os.WriteFile(filepath.Join(local, "config.yaml"), cfgData, 0644)
-	exec.Command("git", "-C", local, "add", ".").Run()
-	exec.Command("git", "-C", local, "commit", "-m", "init").Run()
-	exec.Command("git", "-C", local, "push", "origin", "main").Run()
+	mustExec(t, "git", "-C", local, "add", ".")
+	mustExec(t, "git", "-C", local, "commit", "-m", "init")
+	mustExec(t, "git", "-C", local, "push", "origin", "main")
 
 	// Join from the local path.
 	claudeDir := setupLocalClaude(t, []string{})
@@ -366,9 +373,9 @@ func TestJoin_LocalPath_ResolvesUpstream(t *testing.T) {
 func TestJoin_LocalPath_NoUpstream_KeepsOriginal(t *testing.T) {
 	// Create a local repo with NO origin remote (standalone).
 	local := t.TempDir()
-	exec.Command("git", "init", local).Run()
-	exec.Command("git", "-C", local, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", local, "config", "user.name", "Test").Run()
+	mustExec(t, "git", "init", local)
+	mustExec(t, "git", "-C", local, "config", "user.email", "test@test.com")
+	mustExec(t, "git", "-C", local, "config", "user.name", "Test")
 
 	cfg := config.Config{
 		Version:  "1.0.0",
@@ -378,8 +385,8 @@ func TestJoin_LocalPath_NoUpstream_KeepsOriginal(t *testing.T) {
 	cfgData, err := config.MarshalV2(cfg)
 	require.NoError(t, err)
 	os.WriteFile(filepath.Join(local, "config.yaml"), cfgData, 0644)
-	exec.Command("git", "-C", local, "add", ".").Run()
-	exec.Command("git", "-C", local, "commit", "-m", "init").Run()
+	mustExec(t, "git", "-C", local, "add", ".")
+	mustExec(t, "git", "-C", local, "commit", "-m", "init")
 
 	// Join from the local path (which has no upstream).
 	claudeDir := setupLocalClaude(t, []string{})

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -233,24 +233,38 @@ func HasUpstream(dir string) bool {
 	return err == nil
 }
 
-// SetRemoteURL changes the URL for an existing remote.
+// SetRemoteURL changes the URL for an existing remote. The named remote
+// must already exist; use RemoteAdd to create a new one.
 func SetRemoteURL(dir, name, url string) error {
 	_, err := Run(dir, "remote", "set-url", name, url)
 	return err
 }
 
 // IsLocalPath returns true if the given string looks like a local filesystem
-// path rather than a remote git URL.
+// path rather than a remote git URL. It checks scheme-based URLs (git://,
+// ssh://, https://, http://, file://) and SCP-style URLs (user@host:path).
 func IsLocalPath(s string) bool {
-	for _, prefix := range []string{"git://", "ssh://", "https://", "http://", "git@"} {
+	for _, prefix := range []string{"git://", "ssh://", "https://", "http://", "file://", "git@"} {
 		if strings.HasPrefix(s, prefix) {
 			return false
+		}
+	}
+	// Detect SCP-style URLs: user@host:path (e.g. deploy@host:repo.git).
+	// The git@ case is already handled by the prefix check above.
+	if atIdx := strings.Index(s, "@"); atIdx >= 0 {
+		rest := s[atIdx+1:]
+		if colonIdx := strings.Index(rest, ":"); colonIdx >= 0 {
+			if !strings.Contains(rest[:colonIdx], "/") {
+				return false
+			}
 		}
 	}
 	return true
 }
 
 // ResolveUpstreamURL returns the origin remote URL of a local git repository.
+// It performs a single-hop lookup only: if the returned URL is itself a local
+// path with its own origin, that chain is not followed.
 func ResolveUpstreamURL(localRepoPath string) (string, error) {
 	return RemoteURL(localRepoPath, "origin")
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -113,6 +113,13 @@ func TestRemoteURL_NoRemote(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// mustExec runs a command and fails the test if it errors.
+func mustExec(t *testing.T, name string, args ...string) {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	require.NoError(t, err, "%s %v failed: %s", name, args, string(out))
+}
+
 func TestIsLocalPath(t *testing.T) {
 	tests := []struct {
 		input string
@@ -127,6 +134,10 @@ func TestIsLocalPath(t *testing.T) {
 		{"https://github.com/org/repo", false},
 		{"http://github.com/org/repo", false},
 		{"git@github.com:org/repo.git", false},
+		{"", true},                              // empty string is not a remote URL
+		{"file:///path/to/repo", false},          // file:// scheme is a git transport
+		{"deploy@host:repo.git", false},          // SCP-style with non-git username
+		{"/home/user@name/repo", true},           // @ in local path, no colon after host
 	}
 	for _, tt := range tests {
 		got := git.IsLocalPath(tt.input)
@@ -137,8 +148,8 @@ func TestIsLocalPath(t *testing.T) {
 func TestSetRemoteURL(t *testing.T) {
 	src := initTestRepo(t)
 	os.WriteFile(filepath.Join(src, "test.txt"), []byte("hello"), 0644)
-	exec.Command("git", "-C", src, "add", ".").Run()
-	exec.Command("git", "-C", src, "commit", "-m", "initial").Run()
+	mustExec(t, "git", "-C", src, "add", ".")
+	mustExec(t, "git", "-C", src, "commit", "-m", "initial")
 
 	dst := filepath.Join(t.TempDir(), "clone")
 	err := git.Clone(src, dst)
@@ -157,8 +168,8 @@ func TestResolveUpstreamURL(t *testing.T) {
 	// Create a repo with an origin remote.
 	src := initTestRepo(t)
 	os.WriteFile(filepath.Join(src, "test.txt"), []byte("hello"), 0644)
-	exec.Command("git", "-C", src, "add", ".").Run()
-	exec.Command("git", "-C", src, "commit", "-m", "initial").Run()
+	mustExec(t, "git", "-C", src, "add", ".")
+	mustExec(t, "git", "-C", src, "commit", "-m", "initial")
 
 	// Clone it so the clone has origin pointing to src.
 	clone := filepath.Join(t.TempDir(), "clone")


### PR DESCRIPTION
# User description
## Summary
- When join receives a local filesystem path, resolve its upstream remote URL
- Prevents push failures against non-bare local checkouts
- Falls back to keeping original path if no upstream configured

## Changes
- internal/git/git.go: Added SetRemoteURL(), IsLocalPath(), ResolveUpstreamURL()
- internal/commands/join.go: After clone, detect local paths and resolve upstream
- Tests for all new functions and join behavior

Fixes #10

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add detection in <code>commands.Join</code> so local clone URLs resolve their upstream remote and rewrite the synced repo’s <code>origin</code>, ensuring pushes target the real upstream. Extend the git utilities with <code>IsLocalPath</code>, <code>ResolveUpstreamURL</code>, and <code>SetRemoteURL</code>, providing the helpers tested to support this flow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/17?tool=ast&topic=Git+helper+utils>Git helper utils</a>
        </td><td>Add helper functions to detect local paths, resolve their origin URLs, and override remotes, along with tests covering those behaviors.<details><summary>Modified files (2)</summary><ul><li>internal/git/git.go</li>
<li>internal/git/git_test.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-route-join-to-subs...</td><td>February 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ruminaider/claude-sync/17?tool=ast&topic=Local+join+flow>Local join flow</a>
        </td><td>Update Join to resolve the upstream of a cloned local path and rewrite the synced repo’s <code>origin</code>, preventing pushes from targeting the non‑bare checkout during sync.<details><summary>Modified files (2)</summary><ul><li>internal/commands/join.go</li>
<li>internal/commands/join_test.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>albertgwo@gmail.com</td><td>fix-route-join-to-subs...</td><td>February 28, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/ruminaider/claude-sync/17?tool=ast>(Baz)</a>.