### PR TITLE
fix: handle missing installed_plugins.json gracefully

### DIFF
--- a/internal/claudecode/claudecode.go
+++ b/internal/claudecode/claudecode.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,10 +47,14 @@ func DirExists(claudeDir string) bool {
 }
 
 // ReadInstalledPlugins reads installed_plugins.json.
+// Returns an empty struct when the file does not exist.
 func ReadInstalledPlugins(claudeDir string) (*InstalledPlugins, error) {
 	path := filepath.Join(claudeDir, "plugins", "installed_plugins.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &InstalledPlugins{}, nil
+		}
 		return nil, fmt.Errorf("reading installed plugins: %w", err)
 	}
 	var plugins InstalledPlugins

--- a/internal/claudecode/claudecode_test.go
+++ b/internal/claudecode/claudecode_test.go
@@ -38,8 +38,9 @@ func TestReadInstalledPlugins(t *testing.T) {
 
 func TestReadInstalledPlugins_FileNotFound(t *testing.T) {
 	dir := t.TempDir()
-	_, err := claudecode.ReadInstalledPlugins(dir)
-	assert.Error(t, err)
+	plugins, err := claudecode.ReadInstalledPlugins(dir)
+	require.NoError(t, err)
+	assert.Empty(t, plugins.Plugins)
 }
 
 func TestPluginKeys(t *testing.T) {

--- a/internal/commands/join.go
+++ b/internal/commands/join.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -136,9 +135,6 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 
 	installed, err := claudecode.ReadInstalledPlugins(claudeDir)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return result, nil // No plugins file yet (fresh install) — skip detection
-		}
 		return nil, fmt.Errorf("detecting local plugins: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `ReadInstalledPlugins` now returns an empty struct when `installed_plugins.json` does not exist, fixing `config join` failures on fresh Claude Code installations
- Removed redundant `ErrNotExist` workaround from `join.go` — the callee now owns the "missing file = empty state" contract
- Updated test to assert the new behavior

## Test plan
- [x] `TestReadInstalledPlugins_FileNotFound` updated and passing
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: run `claude-sync config join <url>` on a fresh install with no `installed_plugins.json`

Closes #21