### PR TITLE
fix: exclude bundled plugin from config.yaml forked list

### DIFF
--- a/internal/commands/buildconfig_test.go
+++ b/internal/commands/buildconfig_test.go
@@ -132,6 +132,13 @@ func TestBuildAndWriteConfig_ExtraForked_NoDuplicate(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, count, "claude-sync should not be duplicated in forkedNames")
+
+	// The bundled plugin should be in forkedNames (for internal use) but NOT in config.yaml.
+	cfgData, err := os.ReadFile(filepath.Join(syncDir, "config.yaml"))
+	require.NoError(t, err)
+	cfg, err := config.Parse(cfgData)
+	require.NoError(t, err)
+	assert.NotContains(t, cfg.Forked, "claude-sync", "bundled plugin should not appear in config")
 	_ = result
 }
 

--- a/internal/commands/fork.go
+++ b/internal/commands/fork.go
@@ -124,8 +124,11 @@ func Unfork(claudeDir, syncDir, pluginName, marketplace string) error {
 	// Remove from forked.
 	cfg.Forked = removeFromSlice(cfg.Forked, pluginName)
 
-	// Clean up marketplace entry if no forks remain.
-	if len(cfg.Forked) == 0 {
+	// Clean up marketplace entry if no forks remain on disk.
+	// Uses directory scan instead of cfg.Forked because the bundled plugin
+	// lives on disk but is not tracked in config.
+	forks, _ := forkedplugins.ListForkedPlugins(syncDir)
+	if len(forks) == 0 {
 		_ = forkedplugins.UnregisterLocalMarketplace(claudeDir)
 	}
 

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -596,7 +596,7 @@ func buildAndWriteConfig(opts InitOptions) (*InitResult, []string, error) {
 		Version:      "1.0.0",
 		Upstream:     upstream,
 		Pinned:       map[string]string{},
-		Forked:       forkedNames,
+		Forked:       removeFromSlice(forkedNames, bundled.PluginName),
 		Excluded:     result.ExcludedPlugins,
 		Settings:     cfgSettings,
 		Hooks:        cfgHooks,

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -157,7 +157,7 @@ func TestInit_CreatesV2Config(t *testing.T) {
 	assert.Equal(t, "1.0.0", cfg.Version)
 	assert.NotEmpty(t, cfg.Upstream)
 	assert.Empty(t, cfg.Pinned)
-	assert.Contains(t, cfg.Forked, "claude-sync") // bundled plugin is always included
+	assert.NotContains(t, cfg.Forked, "claude-sync") // bundled plugin should not appear in config
 }
 
 func TestInit_AutoForksNonPortablePlugins(t *testing.T) {
@@ -324,7 +324,7 @@ func TestInit_SkipsClaudeSyncForksEntries(t *testing.T) {
 	cfgData, _ := os.ReadFile(filepath.Join(syncDir, "config.yaml"))
 	cfg, _ := config.Parse(cfgData)
 	assert.Len(t, cfg.Upstream, 2)
-	assert.Equal(t, []string{"claude-sync"}, cfg.Forked) // bundled plugin always present
+	assert.Empty(t, cfg.Forked) // bundled plugin should not appear in config
 }
 
 func TestInit_IncludesLocalScopePlugins(t *testing.T) {
@@ -388,7 +388,7 @@ func TestInit_AllPortableStaysUpstream(t *testing.T) {
 	cfgData, _ := os.ReadFile(filepath.Join(syncDir, "config.yaml"))
 	cfg, _ := config.Parse(cfgData)
 	assert.Len(t, cfg.Upstream, 3)
-	assert.Equal(t, []string{"claude-sync"}, cfg.Forked) // bundled plugin always present
+	assert.Empty(t, cfg.Forked) // bundled plugin should not appear in config
 }
 
 // --- New tests for InitScan and granular Init ---

--- a/internal/commands/join.go
+++ b/internal/commands/join.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -117,18 +116,6 @@ func Join(repoURL, claudeDir, syncDir string) (*JoinResult, error) {
 	bundledPluginDir := filepath.Join(syncDir, "plugins", bundled.PluginName)
 	if err := bundled.ExtractPlugin(bundledPluginDir); err != nil {
 		return nil, fmt.Errorf("extracting bundled plugin: %w", err)
-	}
-
-	// Register the bundled plugin in the Forked list so pull can find it.
-	if !slices.Contains(cfg.Forked, bundled.PluginName) {
-		cfg.Forked = append(cfg.Forked, bundled.PluginName)
-		updatedData, err := config.Marshal(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("marshalling config after forked update: %w", err)
-		}
-		if err := os.WriteFile(cfgPath, updatedData, 0644); err != nil {
-			return nil, fmt.Errorf("writing config after forked update: %w", err)
-		}
 	}
 
 	// Expose config categories so the CLI can prompt about them.

--- a/internal/commands/join_test.go
+++ b/internal/commands/join_test.go
@@ -482,12 +482,12 @@ func TestJoin_ExtractsBundledPlugin(t *testing.T) {
 	_, err = os.Stat(filepath.Join(pluginDir, ".claude-plugin", "plugin.json"))
 	assert.NoError(t, err, "plugin.json should exist after join")
 
-	// Verify bundled plugin is registered in config.yaml Forked list.
+	// Verify bundled plugin is NOT in config.yaml Forked list (it's infrastructure, not a user fork).
 	cfgData, err := os.ReadFile(filepath.Join(syncDir, "config.yaml"))
 	require.NoError(t, err)
 	cfg, err := config.Parse(cfgData)
 	require.NoError(t, err)
-	assert.Contains(t, cfg.Forked, "claude-sync")
+	assert.NotContains(t, cfg.Forked, "claude-sync")
 }
 
 func TestNormalizeURL(t *testing.T) {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/ruminaider/claude-sync/internal/approval"
+	"github.com/ruminaider/claude-sync/internal/bundled"
 	"github.com/ruminaider/claude-sync/internal/claudecode"
 	"github.com/ruminaider/claude-sync/internal/claudemd"
 	"github.com/ruminaider/claude-sync/internal/config"
@@ -126,6 +128,13 @@ func PullDryRun(claudeDir, syncDir string) (*PullResult, error) {
 	}
 	for _, name := range cfg.Forked {
 		allDesired = append(allDesired, plugins.ForkedPluginKey(name))
+	}
+	// Include the bundled plugin in the desired set if it exists on disk.
+	// It is not listed in config.yaml to keep the user-facing config clean.
+	// Without this, exact sync mode would flag it as untracked.
+	bundledKey := plugins.ForkedPluginKey(bundled.PluginName)
+	if slices.Contains(forks, bundled.PluginName) && !slices.Contains(allDesired, bundledKey) {
+		allDesired = append(allDesired, bundledKey)
 	}
 
 	// Apply active profile to desired plugins.

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -119,17 +119,14 @@ func UpdateApply(claudeDir, syncDir string, pluginKeys []string, quiet bool) (in
 		}
 	}
 
-	// Register or unregister local marketplace based on forked plugins in config.
-	cfgData, err := os.ReadFile(filepath.Join(syncDir, "config.yaml"))
-	if err == nil {
-		cfg, err := config.Parse(cfgData)
-		if err == nil {
-			if len(cfg.Forked) > 0 {
-				_ = plugins.RegisterLocalMarketplace(claudeDir, syncDir)
-			} else {
-				_ = plugins.UnregisterLocalMarketplace(claudeDir)
-			}
-		}
+	// Register or unregister local marketplace based on forked plugins on disk.
+	// Uses directory scan instead of cfg.Forked because the bundled plugin
+	// lives on disk but is not tracked in config.
+	forks, _ := plugins.ListForkedPlugins(syncDir)
+	if len(forks) > 0 {
+		_ = plugins.RegisterLocalMarketplace(claudeDir, syncDir)
+	} else {
+		_ = plugins.UnregisterLocalMarketplace(claudeDir)
 	}
 
 	return installed, failed


### PR DESCRIPTION
## Summary

Fixes #43

- Filter the bundled `claude-sync` plugin from `config.yaml`'s `forked:` list at the serialization boundary, while keeping it in the in-memory `forkedNames` for directory management and marketplace registration
- Remove forced config rewrite in `join.go` that added the bundled plugin to `cfg.Forked`
- Add bundled plugin to pull's desired set via disk scan so exact sync mode doesn't flag it as untracked
- Switch `UpdateApply` and `Unfork` marketplace registration checks from config-based to directory-scan-based, consistent with how `pull.go` already does it

## Test plan

- [ ] `go test ./...` passes (all existing + updated tests)
- [ ] Run `claude-sync config update`, confirm "claude-sync" absent from `config.yaml` forked list
- [ ] Run `claude-sync pull`, confirm bundled plugin is still installed and functional
- [ ] Run `claude-sync status`, confirm no errors related to bundled plugin
- [ ] Fork a plugin, then unfork it, confirm marketplace stays registered (bundled plugin still needs it)