### PR TITLE
fix: stop config update from re-excluding upstream plugins for forks

### DIFF
--- a/cmd/claude-sync/tui/root.go
+++ b/cmd/claude-sync/tui/root.go
@@ -1684,7 +1684,8 @@ func applyPickerSelection(p *Picker, selectedSet map[string]bool) {
 
 // applyExistingConfig pre-populates base picker selections from an existing config.
 func (m *Model) applyExistingConfig(cfg *config.Config, existingProfiles map[string]profiles.Profile) {
-	// Plugins: select only those in the existing config.
+	// Plugins: select those in the existing config, plus locally-detected
+	// plugins not explicitly excluded.
 	pluginSet := toSet(cfg.AllPluginKeys())
 	// AllPluginKeys() maps Forked names to name@claude-sync-forks, but the
 	// picker uses scan AutoForked keys (name@original-marketplace). Add
@@ -1693,6 +1694,18 @@ func (m *Model) applyExistingConfig(cfg *config.Config, existingProfiles map[str
 	for _, key := range m.scanResult.AutoForked {
 		parts := strings.SplitN(key, "@", 2)
 		if len(parts) == 2 && forkedNames[parts[0]] {
+			pluginSet[key] = true
+		}
+	}
+	// When a user deselects a plugin during config update it goes into the
+	// excluded list. A plugin that is locally installed but absent from both
+	// the config plugin lists and the excluded list is either newly installed
+	// or was intentionally un-excluded; pre-select it so config update doesn't
+	// silently re-exclude it (#44).
+	excludedSet := toSet(cfg.Excluded)
+	pluginPrefix := commands.ConfigOnlySectionPrefix["plugins"]
+	for _, key := range append(m.scanResult.Upstream, m.scanResult.AutoForked...) {
+		if !pluginSet[key] && !excludedSet[key] && !m.scanResult.ConfigOnly[pluginPrefix+key] {
 			pluginSet[key] = true
 		}
 	}

--- a/cmd/claude-sync/tui/root_test.go
+++ b/cmd/claude-sync/tui/root_test.go
@@ -1976,10 +1976,12 @@ func TestBuildInitOptions_IncludesPluginMCP_WhenPluginDeselected(t *testing.T) {
 func TestNewModel_EditMode_PrePopulatesSelections(t *testing.T) {
 	scan := fullScan()
 
-	// Existing config with only a subset selected.
+	// Existing config with only a subset selected. Plugins not wanted are
+	// in the excluded list (the way config update records deselections).
 	existingCfg := &config.Config{
 		Version:  "1.0.0",
 		Upstream: []string{"a@m"}, // only a@m, not b@m
+		Excluded: []string{"b@m", "c@local"}, // explicitly excluded
 		Settings: map[string]any{"model": "opus"}, // only model, not env
 		Hooks:    map[string]json.RawMessage{"PreToolUse": json.RawMessage(`[{"hooks":[{"command":"lint"}]}]`)},
 		Permissions: config.Permissions{
@@ -1999,14 +2001,14 @@ func TestNewModel_EditMode_PrePopulatesSelections(t *testing.T) {
 	m.overlay = Overlay{}
 	m.overlayCtx = overlayNone
 
-	// Plugins: only a@m selected, not b@m or c@local.
+	// Plugins: only a@m selected; b@m and c@local are excluded.
 	pluginPicker := m.pickers[SectionPlugins]
 	for _, it := range pluginPicker.items {
 		if it.Key == "a@m" {
 			assert.True(t, it.Selected, "a@m should be selected")
 		}
 		if it.Key == "b@m" {
-			assert.False(t, it.Selected, "b@m should NOT be selected")
+			assert.False(t, it.Selected, "b@m should NOT be selected (excluded)")
 		}
 	}
 
@@ -2045,6 +2047,77 @@ func TestNewModel_EditMode_PrePopulatesSelections(t *testing.T) {
 
 	// editMode flag should be set.
 	assert.True(t, m.editMode, "editMode should be true")
+}
+
+// TestEditMode_ForkedPlugin_UpstreamNotReExcluded verifies that when a plugin
+// exists both as a fork and an upstream marketplace entry, the upstream version
+// is pre-selected if it is not in the excluded list. Regression test for #44:
+// config update was silently re-excluding upstream plugins that the user had
+// intentionally removed from the excluded list.
+func TestEditMode_ForkedPlugin_UpstreamNotReExcluded(t *testing.T) {
+	upstreamKey := "my-plugin@my-marketplace"
+	forkedKey := "my-plugin@" + plugins.MarketplaceName
+
+	scan := &commands.InitScanResult{
+		// InitScan finds the upstream marketplace version but skips the
+		// claude-sync-forks version. MergeExisting re-injects the fork.
+		Upstream:   []string{upstreamKey},
+		AutoForked: []string{forkedKey},
+		PluginKeys: []string{upstreamKey, forkedKey},
+		ConfigOnly: map[string]bool{
+			// The fork was injected by MergeExisting (config-only).
+			"plugin:" + forkedKey: true,
+		},
+	}
+
+	existingCfg := &config.Config{
+		Version: "1.0.0",
+		Forked:  []string{"my-plugin"},
+		// Upstream key is NOT in Upstream, NOT in Excluded.
+		// User intentionally removed it from excluded.
+	}
+
+	m := NewModel(scan, "/test/claude", "/test/sync", "", true, SkipFlags{}, existingCfg, nil)
+	m.overlay = Overlay{}
+	m.overlayCtx = overlayNone
+
+	pluginPicker := m.pickers[SectionPlugins]
+	for _, it := range pluginPicker.items {
+		if it.Key == upstreamKey {
+			assert.True(t, it.Selected, "upstream should be pre-selected (not in excluded list)")
+		}
+		if it.Key == forkedKey {
+			assert.True(t, it.Selected, "fork should be pre-selected")
+		}
+	}
+}
+
+// TestEditMode_ExcludedPluginStaysDeselected verifies that explicitly excluded
+// plugins remain deselected in edit mode, complementing the #44 fix.
+func TestEditMode_ExcludedPluginStaysDeselected(t *testing.T) {
+	scan := &commands.InitScanResult{
+		Upstream: []string{"wanted@m", "unwanted@m"},
+	}
+
+	existingCfg := &config.Config{
+		Version:  "1.0.0",
+		Upstream: []string{"wanted@m"},
+		Excluded: []string{"unwanted@m"},
+	}
+
+	m := NewModel(scan, "/test/claude", "/test/sync", "", true, SkipFlags{}, existingCfg, nil)
+	m.overlay = Overlay{}
+	m.overlayCtx = overlayNone
+
+	pluginPicker := m.pickers[SectionPlugins]
+	for _, it := range pluginPicker.items {
+		if it.Key == "wanted@m" {
+			assert.True(t, it.Selected, "wanted@m should be selected")
+		}
+		if it.Key == "unwanted@m" {
+			assert.False(t, it.Selected, "unwanted@m should stay deselected (excluded)")
+		}
+	}
 }
 
 func TestNewModel_EditMode_SkipsOverlay(t *testing.T) {
@@ -2253,6 +2326,7 @@ func TestBuildInitOptions_EditMode(t *testing.T) {
 	existingCfg := &config.Config{
 		Version:  "1.0.0",
 		Upstream: []string{"a@m"},
+		Excluded: []string{"b@m", "c@local"}, // explicitly excluded
 		Settings: map[string]any{"model": "opus"},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #44

- `applyExistingConfig` now pre-selects locally-detected plugins that are not in the excluded list, preventing `config update` from silently re-excluding upstream marketplace plugins that the user intentionally removed from the excluded list
- The excluded list becomes the single source of truth for plugin deselection intent during config update

**Root cause**: When a plugin existed as both a fork and an upstream marketplace entry, the upstream key was absent from every config category (upstream, forked, pinned). After the user removed it from `excluded`, the TUI deselected it on the next `config update`, and `buildAndWriteConfig` re-added it to excluded.

## Test plan

- [ ] `go test ./...` passes (all existing + new tests)
- [ ] New regression test `TestEditMode_ForkedPlugin_UpstreamNotReExcluded` covers the exact #44 scenario
- [ ] New test `TestEditMode_ExcludedPluginStaysDeselected` confirms excluded plugins remain deselected
- [ ] Existing edit-mode tests updated to use `Excluded` field for deselection intent
- [ ] Manual: fork a plugin, run `config update`, remove upstream from excluded, run `config update` again: upstream should not reappear in excluded