### PR TITLE
feat: export project CLAUDE.md fragment content to sync repo

### DIFF
--- a/cmd/claude-sync/tui/root.go
+++ b/cmd/claude-sync/tui/root.go
@@ -192,8 +192,26 @@ func NewModel(scan *commands.InitScanResult, claudeDir, syncDir, remoteURL strin
 		}
 	}
 
-	// Build CLAUDE.md preview.
-	previewSections := ClaudeMDPreviewSections(scan.ClaudeMDSections, "~/.claude/CLAUDE.md")
+	// Build CLAUDE.md preview, partitioning sections by source.
+	// Global sections (Source == "") use ~/.claude/CLAUDE.md as the source.
+	// Project sections use their actual Source path.
+	globalSource := "~/.claude/CLAUDE.md"
+	sourceGroups := make(map[string][]claudemd.Section)
+	var sourceOrder []string
+	for _, sec := range scan.ClaudeMDSections {
+		src := sec.Source
+		if src == "" {
+			src = globalSource
+		}
+		if _, seen := sourceGroups[src]; !seen {
+			sourceOrder = append(sourceOrder, src)
+		}
+		sourceGroups[src] = append(sourceGroups[src], sec)
+	}
+	var previewSections []PreviewSection
+	for _, src := range sourceOrder {
+		previewSections = append(previewSections, ClaudeMDPreviewSections(sourceGroups[src], src)...)
+	}
 
 	// Tag config-only CLAUDE.md fragments.
 	if scan.ConfigOnly != nil {

--- a/internal/claudemd/claudemd.go
+++ b/internal/claudemd/claudemd.go
@@ -21,6 +21,7 @@ type Section struct {
 	Header  string // "" for preamble (content before first ## header)
 	Content string // the full content of the section including the ## header line
 	Group   string // parent fragment name for ### sub-sections; empty for top-level
+	Source  string // source file path (e.g., "~/Work/evvy/CLAUDE.md"); empty for global
 }
 
 // Split splits markdown content on "## " and "### " headers.
@@ -171,9 +172,11 @@ func DirContentHash(dir string) (string, error) {
 
 // FragmentMeta holds metadata about a single fragment.
 type FragmentMeta struct {
-	Header      string `yaml:"header"`
-	ContentHash string `yaml:"content_hash"`
-	Group       string `yaml:"group,omitempty"`
+	Header       string `yaml:"header"`
+	ContentHash  string `yaml:"content_hash"`
+	Group        string `yaml:"group,omitempty"`
+	Source       string `yaml:"source,omitempty"`        // source file path for project fragments
+	QualifiedKey string `yaml:"qualified_key,omitempty"` // original qualified key for project fragments
 }
 
 // Manifest tracks all fragments and their order.
@@ -217,12 +220,102 @@ func WriteFragment(claudeMdDir, name, content string) error {
 }
 
 // ReadFragment reads content from claudeMdDir/name.md.
+// For qualified keys (containing "::"), it resolves the project fragment filename.
 func ReadFragment(claudeMdDir, name string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(claudeMdDir, name+".md"))
+	filename := name
+	if _, _, isProj := ParseQualifiedKey(name); isProj {
+		filename = ProjectFragmentFilename(name)
+	}
+	data, err := os.ReadFile(filepath.Join(claudeMdDir, filename+".md"))
 	if err != nil {
 		return "", err
 	}
 	return string(data), nil
+}
+
+// ParseQualifiedKey splits a fragment key on "::" into source and fragment name.
+// For unqualified keys (no "::"), isProject is false and fragment is the key itself.
+func ParseQualifiedKey(key string) (source, fragment string, isProject bool) {
+	if idx := strings.Index(key, "::"); idx >= 0 {
+		return key[:idx], key[idx+2:], true
+	}
+	return "", key, false
+}
+
+// ProjectFragmentFilename returns the storage filename (without .md extension)
+// for a project fragment. The format is proj--<8-char source hash>--<fragment>.
+func ProjectFragmentFilename(qualifiedKey string) string {
+	source, fragment, _ := ParseQualifiedKey(qualifiedKey)
+	h := sha256.Sum256([]byte(source))
+	prefix := hex.EncodeToString(h[:])[:8]
+	return "proj--" + prefix + "--" + fragment
+}
+
+// ReadProjectFragment reads a project fragment from the claude-md directory.
+func ReadProjectFragment(claudeMdDir, qualifiedKey string) (string, error) {
+	filename := ProjectFragmentFilename(qualifiedKey)
+	return ReadFragment(claudeMdDir, filename)
+}
+
+// WriteProjectFragment writes a project fragment to the claude-md directory.
+func WriteProjectFragment(claudeMdDir, qualifiedKey, content string) error {
+	filename := ProjectFragmentFilename(qualifiedKey)
+	return WriteFragment(claudeMdDir, filename, content)
+}
+
+// ImportProjectFragments reads a project CLAUDE.md file and exports selected
+// sections to the sync repo's claude-md/ directory. It updates the manifest
+// with metadata for each exported fragment.
+func ImportProjectFragments(syncDir, sourcePath, content string, selectedKeys []string) error {
+	claudeMdDir := filepath.Join(syncDir, claudeMdSubdir)
+	if err := os.MkdirAll(claudeMdDir, 0755); err != nil {
+		return err
+	}
+
+	// Build a set of selected fragment names for this source.
+	selectedFragments := make(map[string]bool)
+	for _, key := range selectedKeys {
+		src, frag, isProj := ParseQualifiedKey(key)
+		if isProj && src == sourcePath {
+			selectedFragments[frag] = true
+		}
+	}
+
+	if len(selectedFragments) == 0 {
+		return nil
+	}
+
+	sections := Split(content)
+	manifest, err := ReadManifest(claudeMdDir)
+	if err != nil {
+		return err
+	}
+
+	for _, sec := range sections {
+		fragName := HeaderToFragmentName(sec.Header)
+		if sec.Group != "" {
+			fragName = ChildFragmentName(sec.Group, sec.Header)
+		}
+		if !selectedFragments[fragName] {
+			continue
+		}
+
+		qualifiedKey := sourcePath + "::" + fragName
+		filename := ProjectFragmentFilename(qualifiedKey)
+
+		manifest.Fragments[filename] = FragmentMeta{
+			Header:      sec.Header,
+			ContentHash: ContentHash(sec.Content),
+			Group:       sec.Group,
+			Source:      sourcePath,
+			QualifiedKey: qualifiedKey,
+		}
+		if err := WriteFragment(claudeMdDir, filename, sec.Content); err != nil {
+			return err
+		}
+	}
+
+	return WriteManifest(claudeMdDir, manifest)
 }
 
 // ImportResult holds the result of importing a CLAUDE.md file.

--- a/internal/claudemd/claudemd_test.go
+++ b/internal/claudemd/claudemd_test.go
@@ -320,30 +320,105 @@ func TestChildFragmentName(t *testing.T) {
 		claudemd.ChildFragmentName("work-style", "Git Commits"))
 }
 
+func TestParseQualifiedKey(t *testing.T) {
+	t.Run("global key", func(t *testing.T) {
+		source, frag, isProj := claudemd.ParseQualifiedKey("git-commits")
+		assert.Equal(t, "", source)
+		assert.Equal(t, "git-commits", frag)
+		assert.False(t, isProj)
+	})
+
+	t.Run("project key", func(t *testing.T) {
+		source, frag, isProj := claudemd.ParseQualifiedKey("~/Work/evvy/CLAUDE.md::beads-issue-tracking")
+		assert.Equal(t, "~/Work/evvy/CLAUDE.md", source)
+		assert.Equal(t, "beads-issue-tracking", frag)
+		assert.True(t, isProj)
+	})
+}
+
+func TestProjectFragmentFilename(t *testing.T) {
+	name := claudemd.ProjectFragmentFilename("~/Work/evvy/CLAUDE.md::beads-issue-tracking")
+	assert.Contains(t, name, "proj--")
+	assert.Contains(t, name, "--beads-issue-tracking")
+	assert.Len(t, name, len("proj--12345678--beads-issue-tracking"))
+
+	// Deterministic: same input produces same output.
+	name2 := claudemd.ProjectFragmentFilename("~/Work/evvy/CLAUDE.md::beads-issue-tracking")
+	assert.Equal(t, name, name2)
+
+	// Different source produces different prefix.
+	name3 := claudemd.ProjectFragmentFilename("~/other/project/CLAUDE.md::beads-issue-tracking")
+	assert.NotEqual(t, name, name3)
+}
+
+func TestReadWriteProjectFragment(t *testing.T) {
+	dir := t.TempDir()
+	key := "~/Work/evvy/CLAUDE.md::testing-rules"
+	content := "## Testing Rules\n\nAlways write tests."
+
+	err := claudemd.WriteProjectFragment(dir, key, content)
+	require.NoError(t, err)
+
+	got, err := claudemd.ReadProjectFragment(dir, key)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	// ReadFragment with qualified key should also work.
+	got2, err := claudemd.ReadFragment(dir, key)
+	require.NoError(t, err)
+	assert.Equal(t, content, got2)
+}
+
 func TestDirContentHash(t *testing.T) {
 	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.md"), []byte("hello"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.md"), []byte("world"), 0644))
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("world"), 0644))
-
-	h1, err := claudemd.DirContentHash(dir)
+	hash1, err := claudemd.DirContentHash(dir)
 	require.NoError(t, err)
-	assert.Len(t, h1, 16)
+	assert.Len(t, hash1, 16)
 
-	// Same files, same hash.
-	h2, err := claudemd.DirContentHash(dir)
+	// Same content produces same hash.
+	hash2, err := claudemd.DirContentHash(dir)
 	require.NoError(t, err)
-	assert.Equal(t, h1, h2)
+	assert.Equal(t, hash1, hash2)
 
-	// Modify a file, hash changes.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("changed"), 0644))
-	h3, err := claudemd.DirContentHash(dir)
+	// Modifying a file changes the hash.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.md"), []byte("changed"), 0644))
+	hash3, err := claudemd.DirContentHash(dir)
 	require.NoError(t, err)
-	assert.NotEqual(t, h1, h3)
+	assert.NotEqual(t, hash1, hash3)
+}
 
-	// .DS_Store is ignored.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("junk"), 0644))
-	h4, err := claudemd.DirContentHash(dir)
+func TestImportProjectFragments(t *testing.T) {
+	syncDir := t.TempDir()
+	source := "~/Work/evvy/CLAUDE.md"
+	content := "## Testing Rules\n\nAlways write tests.\n\n## Docker Setup\n\nUse compose.\n"
+	selectedKeys := []string{
+		source + "::testing-rules",
+	}
+
+	err := claudemd.ImportProjectFragments(syncDir, source, content, selectedKeys)
 	require.NoError(t, err)
-	assert.Equal(t, h3, h4, ".DS_Store should be ignored")
+
+	// The selected fragment should be readable.
+	key := source + "::testing-rules"
+	got, err := claudemd.ReadFragment(filepath.Join(syncDir, "claude-md"), key)
+	require.NoError(t, err)
+	assert.Contains(t, got, "Testing Rules")
+
+	// The non-selected fragment should not exist.
+	key2 := source + "::docker-setup"
+	_, err = claudemd.ReadFragment(filepath.Join(syncDir, "claude-md"), key2)
+	assert.Error(t, err)
+
+	// Manifest should have the fragment metadata.
+	manifest, err := claudemd.ReadManifest(filepath.Join(syncDir, "claude-md"))
+	require.NoError(t, err)
+	filename := claudemd.ProjectFragmentFilename(key)
+	meta, ok := manifest.Fragments[filename]
+	assert.True(t, ok)
+	assert.Equal(t, "Testing Rules", meta.Header)
+	assert.Equal(t, source, meta.Source)
+	assert.Equal(t, key, meta.QualifiedKey)
 }

--- a/internal/claudemd/reconcile.go
+++ b/internal/claudemd/reconcile.go
@@ -3,6 +3,7 @@ package claudemd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // RenamedFragment describes a fragment whose header changed but content is similar.
@@ -152,4 +153,83 @@ func Reconcile(syncDir, currentContent string) (*ReconcileResult, error) {
 	}
 
 	return result, nil
+}
+
+// ReconcileProjectFragments compares current project CLAUDE.md content against
+// stored project fragments and updates any that changed. The qualifiedKeys list
+// contains keys like "~/Work/evvy/CLAUDE.md::section-name". The expandHome
+// function resolves "~/" to the user's home directory.
+func ReconcileProjectFragments(syncDir string, qualifiedKeys []string, expandHome func(string) string) (updated int, err error) {
+	claudeMdDir := filepath.Join(syncDir, claudeMdSubdir)
+
+	manifest, err := ReadManifest(claudeMdDir)
+	if err != nil {
+		return 0, err
+	}
+
+	// Group keys by source path.
+	sourceKeys := make(map[string][]string)
+	for _, key := range qualifiedKeys {
+		if !strings.Contains(key, "::") {
+			continue
+		}
+		source, _, _ := ParseQualifiedKey(key)
+		sourceKeys[source] = append(sourceKeys[source], key)
+	}
+
+	changed := false
+	for source, keys := range sourceKeys {
+		expanded := expandHome(source)
+		data, readErr := os.ReadFile(expanded)
+		if readErr != nil {
+			continue // source not available on this machine
+		}
+
+		sections := Split(string(data))
+
+		// Build lookup from fragment name to section.
+		sectionMap := make(map[string]Section)
+		for _, sec := range sections {
+			name := HeaderToFragmentName(sec.Header)
+			if sec.Group != "" {
+				name = ChildFragmentName(sec.Group, sec.Header)
+			}
+			sectionMap[name] = sec
+		}
+
+		for _, key := range keys {
+			_, fragName, _ := ParseQualifiedKey(key)
+			sec, ok := sectionMap[fragName]
+			if !ok {
+				continue
+			}
+
+			filename := ProjectFragmentFilename(key)
+			meta, exists := manifest.Fragments[filename]
+			newHash := ContentHash(sec.Content)
+
+			if !exists || newHash != meta.ContentHash {
+				if writeErr := WriteFragment(claudeMdDir, filename, sec.Content); writeErr != nil {
+					return updated, writeErr
+				}
+				manifest.Fragments[filename] = FragmentMeta{
+					Header:       sec.Header,
+					ContentHash:  newHash,
+					Group:        sec.Group,
+					Source:       source,
+					QualifiedKey: key,
+				}
+				updated++
+				changed = true
+			}
+		}
+	}
+
+	if changed {
+		if writeErr := WriteManifest(claudeMdDir, manifest); writeErr != nil {
+			return updated, writeErr
+		}
+	}
+
+	return updated, nil
 }

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -647,10 +647,30 @@ func buildAndWriteConfig(opts InitOptions) (*InitResult, []string, error) {
 		}
 	}
 
-	// Append project CLAUDE.md fragment selections to config. These are qualified
-	// keys (with "::") that track which project fragments the user selected.
+	// Append project CLAUDE.md fragment selections to config and export their
+	// content to the sync repo so other machines can resolve them.
 	if len(opts.ProjectClaudeMDFragments) > 0 {
 		cfg.ClaudeMD.Include = append(cfg.ClaudeMD.Include, opts.ProjectClaudeMDFragments...)
+
+		// Group selected fragments by source path and export content.
+		sourceFragments := make(map[string][]string)
+		for _, key := range opts.ProjectClaudeMDFragments {
+			source, _, isProj := claudemd.ParseQualifiedKey(key)
+			if isProj {
+				sourceFragments[source] = append(sourceFragments[source], key)
+			}
+		}
+		for source, keys := range sourceFragments {
+			expanded := expandHome(source)
+			data, readErr := os.ReadFile(expanded)
+			if readErr != nil {
+				continue // source not available on this machine; skip export
+			}
+			if exportErr := claudemd.ImportProjectFragments(syncDir, source, string(data), keys); exportErr != nil {
+				return nil, nil, fmt.Errorf("exporting project CLAUDE.md fragments from %s: %w", source, exportErr)
+			}
+		}
+
 		cfgData, err = config.Marshal(cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("marshaling config with project CLAUDE.md: %w", err)

--- a/internal/commands/merge_config.go
+++ b/internal/commands/merge_config.go
@@ -244,9 +244,19 @@ func mergeClaudeMDFragments(scan *InitScanResult, fragments []string, syncDir st
 			continue
 		}
 
+		source, _, isProject := claudemd.ParseQualifiedKey(fragKey)
+
 		content, err := claudemd.ReadFragment(claudeMdDir, fragKey)
 		if err != nil {
-			// Fragment file not available locally; inject a placeholder.
+			if isProject {
+				// Project fragment not available: skip the placeholder entirely.
+				// The key is preserved in config.yaml but showing a garbled
+				// qualified key as a section header confuses the user.
+				scan.ConfigOnly["fragment:"+fragKey] = true
+				existing[fragKey] = true
+				continue
+			}
+			// Global fragment not available: inject placeholder as before.
 			placeholder := claudemd.Section{
 				Header:  fragKey,
 				Content: fmt.Sprintf("## %s\n\n(fragment not available locally)", fragKey),
@@ -255,6 +265,11 @@ func mergeClaudeMDFragments(scan *InitScanResult, fragments []string, syncDir st
 		} else {
 			// Split the fragment content and append all resulting sections.
 			sections := claudemd.Split(content)
+			for i := range sections {
+				if isProject {
+					sections[i].Source = source
+				}
+			}
 			scan.ClaudeMDSections = append(scan.ClaudeMDSections, sections...)
 		}
 

--- a/internal/commands/merge_config_test.go
+++ b/internal/commands/merge_config_test.go
@@ -538,6 +538,62 @@ func TestMergeExistingConfig_ClaudeMDFragments_NoDuplicates(t *testing.T) {
 	})
 }
 
+func TestMergeClaudeMDFragments_SkipsUnavailableProjectFragment(t *testing.T) {
+	t.Run("does not inject placeholder for unavailable project fragment", func(t *testing.T) {
+		syncDir := t.TempDir()
+		// No exported project fragment file exists in claude-md/.
+
+		scan := &commands.InitScanResult{}
+		cfg := &config.Config{
+			ClaudeMD: config.ClaudeMDConfig{
+				Include: []string{"~/Work/evvy/CLAUDE.md::beads-issue-tracking"},
+			},
+		}
+
+		commands.MergeExistingConfig(scan, cfg, syncDir)
+
+		// No section should be added: project fragments without exported
+		// content are silently skipped to avoid garbled qualified keys.
+		assert.Empty(t, scan.ClaudeMDSections)
+
+		// The key should still be tracked in ConfigOnly so it isn't lost.
+		assert.True(t, scan.ConfigOnly["fragment:~/Work/evvy/CLAUDE.md::beads-issue-tracking"])
+	})
+}
+
+func TestMergeClaudeMDFragments_InjectsAvailableProjectFragment(t *testing.T) {
+	t.Run("injects sections with Source from exported project fragment", func(t *testing.T) {
+		syncDir := t.TempDir()
+		claudeMdDir := filepath.Join(syncDir, "claude-md")
+		require.NoError(t, os.MkdirAll(claudeMdDir, 0755))
+
+		qualifiedKey := "~/Work/evvy/CLAUDE.md::beads-issue-tracking"
+		fragFilename := claudemd.ProjectFragmentFilename(qualifiedKey)
+		fragContent := "## Beads Issue Tracking\n\nTrack issues in Linear project BEADS."
+
+		require.NoError(t, os.WriteFile(
+			filepath.Join(claudeMdDir, fragFilename+".md"),
+			[]byte(fragContent), 0644,
+		))
+
+		scan := &commands.InitScanResult{}
+		cfg := &config.Config{
+			ClaudeMD: config.ClaudeMDConfig{
+				Include: []string{qualifiedKey},
+			},
+		}
+
+		commands.MergeExistingConfig(scan, cfg, syncDir)
+
+		// The exported content should be split and injected with the correct Source.
+		require.Len(t, scan.ClaudeMDSections, 1)
+		assert.Equal(t, "Beads Issue Tracking", scan.ClaudeMDSections[0].Header)
+		assert.Equal(t, "~/Work/evvy/CLAUDE.md", scan.ClaudeMDSections[0].Source)
+		assert.Contains(t, scan.ClaudeMDSections[0].Content, "Track issues in Linear project BEADS")
+		assert.True(t, scan.ConfigOnly["fragment:"+qualifiedKey])
+	})
+}
+
 func TestMergeExistingConfig_ClaudeMDFragments_EmptyInclude(t *testing.T) {
 	t.Run("no-op when config has no CLAUDE.md includes", func(t *testing.T) {
 		scan := &commands.InitScanResult{}

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -149,6 +149,20 @@ func PushScan(claudeDir, syncDir string) (*PushScanResult, error) {
 		}
 	}
 
+	// Reconcile project CLAUDE.md fragments.
+	if len(cfg.ClaudeMD.Include) > 0 {
+		projUpdated, projErr := claudemd.ReconcileProjectFragments(syncDir, cfg.ClaudeMD.Include, expandHome)
+		if projErr == nil && projUpdated > 0 {
+			if result.ChangedClaudeMD == nil {
+				result.ChangedClaudeMD = &claudemd.ReconcileResult{}
+			}
+			// Count project fragment updates alongside global ones.
+			for i := 0; i < projUpdated; i++ {
+				result.ChangedClaudeMD.Updated = append(result.ChangedClaudeMD.Updated, "(project fragment)")
+			}
+		}
+	}
+
 	// Scan memory changes.
 	syncMemDir := filepath.Join(syncDir, "memory")
 	memSources := []string{filepath.Join(claudeDir, "memory")}


### PR DESCRIPTION
## Summary

Completes the half-implemented project CLAUDE.md fragment feature. Previously, selecting project CLAUDE.md sections in the TUI stored qualified keys (e.g., `~/Work/evvy/CLAUDE.md::beads-issue-tracking`) in config.yaml but never exported the content. On other machines, these keys were unresolvable, causing garbled strings in the TUI.

- Export selected project sections to `claude-md/` during config init/update via `ImportProjectFragments`
- Add `ParseQualifiedKey`, `ProjectFragmentFilename`, and project fragment read/write helpers
- Enhance `ReadFragment` to resolve qualified keys through `ProjectFragmentFilename`
- Add `ReconcileProjectFragments` for push-direction content updates
- Skip garbled placeholder display for unavailable project fragments in `mergeClaudeMDFragments`
- Group TUI preview sections by source file instead of hardcoding `~/.claude/CLAUDE.md`

Depends on #48 (for `DirContentHash` in shared `claudemd.go`).

## Test plan

- [x] `TestParseQualifiedKey`: splits global and project keys correctly
- [x] `TestProjectFragmentFilename`: deterministic filename with 8-char source hash
- [x] `TestReadWriteProjectFragment`: round-trip read/write with qualified keys
- [x] `TestImportProjectFragments`: exports selected sections, skips unselected, updates manifest
- [x] `TestMergeClaudeMDFragments_SkipsUnavailableProjectFragment`: no placeholder for missing project fragments
- [x] `TestMergeClaudeMDFragments_InjectsAvailableProjectFragment`: real content injected with correct Source
- [x] All existing tests pass (`go test ./...`)