### PR TITLE
fix: preserve executable permissions on hook shell scripts

### DIFF
--- a/internal/bundled/plugin.go
+++ b/internal/bundled/plugin.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // The all: prefix is required so that go:embed includes dotfiles such as
@@ -73,7 +74,11 @@ func ExtractPlugin(dstDir string) error {
 			return fmt.Errorf("creating directory %s: %w", filepath.Dir(target), err)
 		}
 
-		if err := os.WriteFile(target, data, 0644); err != nil {
+		perm := os.FileMode(0644)
+		if strings.HasSuffix(path, ".sh") {
+			perm = 0755
+		}
+		if err := os.WriteFile(target, data, perm); err != nil {
 			return fmt.Errorf("writing %s: %w", target, err)
 		}
 		return nil

--- a/internal/bundled/plugin_test.go
+++ b/internal/bundled/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,6 +43,32 @@ func TestExtractPlugin(t *testing.T) {
 	}
 	if _, ok := parsed["name"]; !ok {
 		t.Error("plugin.json missing 'name' field")
+	}
+}
+
+func TestExtractPlugin_ShellScriptsAreExecutable(t *testing.T) {
+	dstDir := filepath.Join(t.TempDir(), "claude-sync")
+
+	if err := ExtractPlugin(dstDir); err != nil {
+		t.Fatalf("ExtractPlugin failed: %v", err)
+	}
+
+	// Walk the extracted directory and check that all .sh files are executable.
+	err := filepath.Walk(dstDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".sh") {
+			return nil
+		}
+		if info.Mode()&0111 == 0 {
+			rel, _ := filepath.Rel(dstDir, path)
+			t.Errorf("%s is not executable (mode %o)", rel, info.Mode())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking extracted directory: %v", err)
 	}
 }
 

--- a/internal/commands/fork.go
+++ b/internal/commands/fork.go
@@ -203,11 +203,16 @@ func copyFile(src, dst string) error {
 	}
 	defer in.Close()
 
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}
 
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/internal/commands/fork_test.go
+++ b/internal/commands/fork_test.go
@@ -31,6 +31,8 @@ func setupForkTestEnv(t *testing.T) (claudeDir, syncDir string) {
 	require.NoError(t, os.WriteFile(filepath.Join(pluginCacheDir, "manifest.json"), []byte(`{"name":"test-plugin"}`), 0644))
 	require.NoError(t, os.MkdirAll(filepath.Join(pluginCacheDir, "src"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(pluginCacheDir, "src", "index.js"), []byte(`console.log("hello")`), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginCacheDir, "hooks"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginCacheDir, "hooks", "start.sh"), []byte("#!/bin/bash\necho hi"), 0755))
 
 	// Create installed_plugins.json pointing to the cache dir.
 	pluginsDir := filepath.Join(claudeDir, "plugins")
@@ -96,6 +98,11 @@ func TestFork(t *testing.T) {
 	indexJS, err := os.ReadFile(filepath.Join(syncDir, "plugins", "test-plugin", "src", "index.js"))
 	require.NoError(t, err)
 	assert.Contains(t, string(indexJS), "hello")
+
+	// Verify executable permissions are preserved on .sh files.
+	shInfo, err := os.Stat(filepath.Join(syncDir, "plugins", "test-plugin", "hooks", "start.sh"))
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), shInfo.Mode()&0111, "shell script should be executable after fork copy")
 
 	// Verify config was updated.
 	cfgData, err := os.ReadFile(filepath.Join(syncDir, "config.yaml"))


### PR DESCRIPTION
## Summary

- `ExtractPlugin` in `bundled/plugin.go` wrote all embedded files with hardcoded `0644`, stripping the execute bit from `.sh` hook scripts. Now uses `0755` for `.sh` files.
- `copyFile` in `fork.go` used `os.Create` (which defaults to `0644`), ignoring the source file's permissions. Now preserves the source mode via `os.Stat` + `os.OpenFile`.

This caused "Permission denied" errors when Claude Code tried to execute plugin hook scripts (e.g., `stop-change-check.sh`, `session-start.sh`).

## Test plan

- [x] `TestExtractPlugin_ShellScriptsAreExecutable`: walks extracted plugin and verifies all `.sh` files have execute bit set
- [x] `TestFork`: extended to include an executable `.sh` file in the test fixture and verify permissions are preserved after fork copy
- [x] Full test suite passes (`go test ./...`)