### PR TITLE
fix: plugin browser now applies selections to config

### DIFF
--- a/cmd/claude-sync/tui/app.go
+++ b/cmd/claude-sync/tui/app.go
@@ -162,6 +162,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		return m, nil
+	case subscribeResultMsg:
+		// Route to sub-view
+		if m.subView != nil {
+			var cmd tea.Cmd
+			m.subView, cmd = m.subView.Update(msg)
+			return m, cmd
+		}
+		return m, nil
 	case tea.KeyMsg:
 		// Global keys (work in any view unless filter/help is active)
 		if msg.String() == "ctrl+c" {

--- a/cmd/claude-sync/tui/app.go
+++ b/cmd/claude-sync/tui/app.go
@@ -154,6 +154,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		return m, nil
+	case pluginBrowserResultMsg:
+		// Route to sub-view
+		if m.subView != nil {
+			var cmd tea.Cmd
+			m.subView, cmd = m.subView.Update(msg)
+			return m, cmd
+		}
+		return m, nil
 	case tea.KeyMsg:
 		// Global keys (work in any view unless filter/help is active)
 		if msg.String() == "ctrl+c" {
@@ -342,6 +350,7 @@ func (m AppModel) openSubView(actionID string) (tea.Model, tea.Cmd) {
 		m.activeView = viewSubView
 	case ActionBrowsePlugins:
 		browser := NewPluginBrowser(m.state, m.width, m.height)
+		browser.syncDir = m.syncDir
 		m.subView = browser
 		m.activeView = viewSubView
 	case "join-config":

--- a/cmd/claude-sync/tui/app.go
+++ b/cmd/claude-sync/tui/app.go
@@ -357,9 +357,7 @@ func (m AppModel) openSubView(actionID string) (tea.Model, tea.Cmd) {
 		m.subView = picker
 		m.activeView = viewSubView
 	case ActionBrowsePlugins:
-		browser := NewPluginBrowser(m.state, m.width, m.height)
-		browser.syncDir = m.syncDir
-		m.subView = browser
+		m.subView = NewPluginBrowser(m.state, m.syncDir, m.width, m.height)
 		m.activeView = viewSubView
 	case "join-config":
 		jf := NewJoinFlow(m.width, m.height)

--- a/cmd/claude-sync/tui/subview_plugins.go
+++ b/cmd/claude-sync/tui/subview_plugins.go
@@ -53,21 +53,22 @@ type PluginBrowser struct {
 	syncDir string
 
 	// Execution state
-	executing     bool
-	resultDone    bool
-	resultSuccess bool
-	resultMsg     string
+	executing  bool
+	resultDone bool
+	resultOk   bool
+	resultMsg  string
 }
 
 // NewPluginBrowser creates a PluginBrowser from the current menu state.
 // Items are organized by marketplace section, with installed plugins pre-checked.
-func NewPluginBrowser(state commands.MenuState, width, height int) PluginBrowser {
+func NewPluginBrowser(state commands.MenuState, syncDir string, width, height int) PluginBrowser {
 	items := buildPluginBrowserItems(state.Plugins)
 
 	m := PluginBrowser{
-		items:  items,
-		width:  width,
-		height: height,
+		items:   items,
+		syncDir: syncDir,
+		width:   width,
+		height:  height,
 	}
 
 	// Position cursor on the first non-header item
@@ -156,14 +157,14 @@ func (m PluginBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case pluginBrowserResultMsg:
 		m.executing = false
 		m.resultDone = true
-		m.resultSuccess = msg.success
+		m.resultOk = msg.success
 		m.resultMsg = resolveResultMsg(msg.success, msg.message, msg.err)
 		return m, nil
 	case tea.KeyMsg:
 		// After result is shown, any key dismisses
 		if m.resultDone {
 			return m, func() tea.Msg {
-				return subViewCloseMsg{refreshState: true}
+				return subViewCloseMsg{refreshState: m.resultOk}
 			}
 		}
 		// While executing, ignore input
@@ -353,7 +354,7 @@ func (m PluginBrowser) View() string {
 
 	// Result state
 	if m.resultDone {
-		lines = renderResultLines(lines, m.resultSuccess, m.resultMsg)
+		lines = renderResultLines(lines, m.resultOk, m.resultMsg)
 		content := strings.Join(lines, "\n")
 		boxStyle := contentBox(maxWidth, colorSurface1)
 		return boxStyle.Render(content)
@@ -471,11 +472,22 @@ func (m PluginBrowser) View() string {
 
 // applyPluginSelections modifies config.yaml to add or exclude plugins, then commits.
 func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
+	if syncDir == "" {
+		return func() tea.Msg {
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Sync directory is not configured",
+				err:     fmt.Errorf("syncDir is empty"),
+			}
+		}
+	}
+
 	return func() (result tea.Msg) {
 		defer func() {
 			if r := recover(); r != nil {
 				result = pluginBrowserResultMsg{
 					success: false,
+					message: fmt.Sprintf("Internal error: %v", r),
 					err:     fmt.Errorf("panic: %v", r),
 				}
 			}
@@ -484,12 +496,20 @@ func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
 		cfgPath := filepath.Join(syncDir, "config.yaml")
 		cfgData, err := os.ReadFile(cfgPath)
 		if err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not read config.yaml",
+				err:     err,
+			}
 		}
 
 		cfg, err := config.Parse(cfgData)
 		if err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not parse config.yaml",
+				err:     err,
+			}
 		}
 
 		// Add newly selected plugins to Upstream, remove them from Excluded
@@ -506,15 +526,29 @@ func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
 
 		newData, err := config.Marshal(cfg)
 		if err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not serialize config",
+				err:     err,
+			}
 		}
 
 		if err := os.WriteFile(cfgPath, newData, 0644); err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not write config.yaml",
+				err:     err,
+			}
 		}
 
+		// From here, the file is modified on disk. Rollback on failure.
 		if err := git.Add(syncDir, "config.yaml"); err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			os.WriteFile(cfgPath, cfgData, 0644) // restore original
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not stage config.yaml",
+				err:     err,
+			}
 		}
 
 		var parts []string
@@ -527,7 +561,12 @@ func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
 		summary := strings.Join(parts, ", ")
 
 		if err := git.Commit(syncDir, "Update plugins: "+summary); err != nil {
-			return pluginBrowserResultMsg{success: false, err: err}
+			os.WriteFile(cfgPath, cfgData, 0644) // restore original
+			return pluginBrowserResultMsg{
+				success: false,
+				message: "Could not commit changes",
+				err:     err,
+			}
 		}
 
 		return pluginBrowserResultMsg{success: true, message: "Updated plugins: " + summary}

--- a/cmd/claude-sync/tui/subview_plugins.go
+++ b/cmd/claude-sync/tui/subview_plugins.go
@@ -2,12 +2,16 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ruminaider/claude-sync/internal/commands"
+	"github.com/ruminaider/claude-sync/internal/config"
+	"github.com/ruminaider/claude-sync/internal/git"
 )
 
 // pluginBrowserItem represents a single row in the plugin browser (either a header or a plugin).
@@ -23,6 +27,13 @@ type pluginBrowserItem struct {
 	isHeader    bool   // marketplace section header (not selectable)
 }
 
+// pluginBrowserResultMsg carries the outcome of applying plugin selections.
+type pluginBrowserResultMsg struct {
+	success bool
+	message string
+	err     error
+}
+
 // PluginBrowser is a sub-view for browsing and selecting plugins.
 type PluginBrowser struct {
 	items      []pluginBrowserItem
@@ -33,8 +44,18 @@ type PluginBrowser struct {
 	filterText string
 	filterMode bool
 	// After confirmation
-	confirmed     bool
-	newSelections []string // keys of newly selected plugins
+	confirmed         bool
+	newSelections     []string // keys of newly selected plugins
+	removedSelections []string // keys of deselected installed plugins
+
+	// Paths for execution
+	syncDir string
+
+	// Execution state
+	executing     bool
+	resultDone    bool
+	resultSuccess bool
+	resultMsg     string
 }
 
 // NewPluginBrowser creates a PluginBrowser from the current menu state.
@@ -131,7 +152,23 @@ func (m PluginBrowser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		return m, nil
+	case pluginBrowserResultMsg:
+		m.executing = false
+		m.resultDone = true
+		m.resultSuccess = msg.success
+		m.resultMsg = resolveResultMsg(msg.success, msg.message, msg.err)
+		return m, nil
 	case tea.KeyMsg:
+		// After result is shown, any key dismisses
+		if m.resultDone {
+			return m, func() tea.Msg {
+				return subViewCloseMsg{refreshState: true}
+			}
+		}
+		// While executing, ignore input
+		if m.executing {
+			return m, nil
+		}
 		if m.filterMode {
 			return m.updateFilterMode(msg)
 		}
@@ -160,22 +197,29 @@ func (m PluginBrowser) updateNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.confirmed = true
 		// Check if selections changed from initial installed state
-		hasChanges := false
 		var newSelections []string
+		var removedSelections []string
 		for _, item := range m.items {
 			if item.isHeader {
 				continue
 			}
-			if item.selected != item.installed {
-				hasChanges = true
-			}
 			if item.selected && !item.installed {
 				newSelections = append(newSelections, item.key)
 			}
+			if !item.selected && item.installed {
+				removedSelections = append(removedSelections, item.key)
+			}
 		}
 		m.newSelections = newSelections
+		m.removedSelections = removedSelections
+
+		if len(newSelections) > 0 || len(removedSelections) > 0 {
+			m.executing = true
+			return m, applyPluginSelections(m.syncDir, newSelections, removedSelections)
+		}
+		// No changes, close immediately
 		return m, func() tea.Msg {
-			return subViewCloseMsg{refreshState: hasChanges}
+			return subViewCloseMsg{refreshState: false}
 		}
 	}
 	return m, nil
@@ -306,6 +350,22 @@ func (m PluginBrowser) View() string {
 	lines = append(lines, headerStyle.Render("Add or discover new plugins"))
 	lines = append(lines, "")
 
+	// Result state
+	if m.resultDone {
+		lines = renderResultLines(lines, m.resultSuccess, m.resultMsg)
+		content := strings.Join(lines, "\n")
+		boxStyle := contentBox(maxWidth, colorSurface1)
+		return boxStyle.Render(content)
+	}
+
+	// Executing state
+	if m.executing {
+		lines = append(lines, stYellow.Render("\u27f3 Applying plugin changes..."))
+		content := strings.Join(lines, "\n")
+		boxStyle := contentBox(maxWidth, colorSurface1)
+		return boxStyle.Render(content)
+	}
+
 	// Filter line
 	if m.filterMode {
 		lines = append(lines, stBlue.Render("/ "+m.filterText+"\u2588"))
@@ -406,4 +466,102 @@ func (m PluginBrowser) View() string {
 	boxStyle := contentBox(maxWidth, colorSurface1)
 
 	return boxStyle.Render(content)
+}
+
+// applyPluginSelections modifies config.yaml to add or exclude plugins, then commits.
+func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
+	return func() (result tea.Msg) {
+		defer func() {
+			if r := recover(); r != nil {
+				result = pluginBrowserResultMsg{
+					success: false,
+					err:     fmt.Errorf("panic: %v", r),
+				}
+			}
+		}()
+
+		cfgPath := filepath.Join(syncDir, "config.yaml")
+		cfgData, err := os.ReadFile(cfgPath)
+		if err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		cfg, err := config.Parse(cfgData)
+		if err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		// Add newly selected plugins to Upstream, remove them from Excluded
+		if len(toAdd) > 0 {
+			cfg.Upstream = appendUnique(cfg.Upstream, toAdd)
+			cfg.Excluded = removeStrings(cfg.Excluded, toAdd)
+		}
+
+		// Add deselected plugins to Excluded, remove them from Upstream
+		if len(toRemove) > 0 {
+			cfg.Excluded = appendUnique(cfg.Excluded, toRemove)
+			cfg.Upstream = removeStrings(cfg.Upstream, toRemove)
+		}
+
+		newData, err := config.Marshal(cfg)
+		if err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		if err := os.WriteFile(cfgPath, newData, 0644); err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		if err := git.Add(syncDir, "config.yaml"); err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		parts := []string{}
+		if len(toAdd) > 0 {
+			parts = append(parts, fmt.Sprintf("added %d", len(toAdd)))
+		}
+		if len(toRemove) > 0 {
+			parts = append(parts, fmt.Sprintf("excluded %d", len(toRemove)))
+		}
+		commitMsg := fmt.Sprintf("Update plugins: %s", strings.Join(parts, ", "))
+
+		if err := git.Commit(syncDir, commitMsg); err != nil {
+			return pluginBrowserResultMsg{success: false, err: err}
+		}
+
+		msg := fmt.Sprintf("Updated plugins: %s", strings.Join(parts, ", "))
+		return pluginBrowserResultMsg{success: true, message: msg}
+	}
+}
+
+// appendUnique appends items from add to base without duplicates.
+func appendUnique(base, add []string) []string {
+	seen := make(map[string]bool, len(base))
+	for _, s := range base {
+		seen[s] = true
+	}
+	result := make([]string, len(base))
+	copy(result, base)
+	for _, s := range add {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// removeStrings returns base with all items in remove filtered out.
+func removeStrings(base, remove []string) []string {
+	drop := make(map[string]bool, len(remove))
+	for _, s := range remove {
+		drop[s] = true
+	}
+	var result []string
+	for _, s := range base {
+		if !drop[s] {
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/cmd/claude-sync/tui/subview_plugins.go
+++ b/cmd/claude-sync/tui/subview_plugins.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ruminaider/claude-sync/internal/commands"
 	"github.com/ruminaider/claude-sync/internal/config"
 	"github.com/ruminaider/claude-sync/internal/git"
+	"github.com/ruminaider/claude-sync/internal/sliceutil"
 )
 
 // pluginBrowserItem represents a single row in the plugin browser (either a header or a plugin).
@@ -493,14 +494,14 @@ func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
 
 		// Add newly selected plugins to Upstream, remove them from Excluded
 		if len(toAdd) > 0 {
-			cfg.Upstream = appendUnique(cfg.Upstream, toAdd)
-			cfg.Excluded = removeStrings(cfg.Excluded, toAdd)
+			cfg.Upstream = sliceutil.AppendUnique(cfg.Upstream, toAdd)
+			cfg.Excluded = sliceutil.RemoveAll(cfg.Excluded, toAdd)
 		}
 
 		// Add deselected plugins to Excluded, remove them from Upstream
 		if len(toRemove) > 0 {
-			cfg.Excluded = appendUnique(cfg.Excluded, toRemove)
-			cfg.Upstream = removeStrings(cfg.Upstream, toRemove)
+			cfg.Excluded = sliceutil.AppendUnique(cfg.Excluded, toRemove)
+			cfg.Upstream = sliceutil.RemoveAll(cfg.Upstream, toRemove)
 		}
 
 		newData, err := config.Marshal(cfg)
@@ -516,52 +517,19 @@ func applyPluginSelections(syncDir string, toAdd, toRemove []string) tea.Cmd {
 			return pluginBrowserResultMsg{success: false, err: err}
 		}
 
-		parts := []string{}
+		var parts []string
 		if len(toAdd) > 0 {
 			parts = append(parts, fmt.Sprintf("added %d", len(toAdd)))
 		}
 		if len(toRemove) > 0 {
 			parts = append(parts, fmt.Sprintf("excluded %d", len(toRemove)))
 		}
-		commitMsg := fmt.Sprintf("Update plugins: %s", strings.Join(parts, ", "))
+		summary := strings.Join(parts, ", ")
 
-		if err := git.Commit(syncDir, commitMsg); err != nil {
+		if err := git.Commit(syncDir, "Update plugins: "+summary); err != nil {
 			return pluginBrowserResultMsg{success: false, err: err}
 		}
 
-		msg := fmt.Sprintf("Updated plugins: %s", strings.Join(parts, ", "))
-		return pluginBrowserResultMsg{success: true, message: msg}
+		return pluginBrowserResultMsg{success: true, message: "Updated plugins: " + summary}
 	}
-}
-
-// appendUnique appends items from add to base without duplicates.
-func appendUnique(base, add []string) []string {
-	seen := make(map[string]bool, len(base))
-	for _, s := range base {
-		seen[s] = true
-	}
-	result := make([]string, len(base))
-	copy(result, base)
-	for _, s := range add {
-		if !seen[s] {
-			seen[s] = true
-			result = append(result, s)
-		}
-	}
-	return result
-}
-
-// removeStrings returns base with all items in remove filtered out.
-func removeStrings(base, remove []string) []string {
-	drop := make(map[string]bool, len(remove))
-	for _, s := range remove {
-		drop[s] = true
-	}
-	var result []string
-	for _, s := range base {
-		if !drop[s] {
-			result = append(result, s)
-		}
-	}
-	return result
 }

--- a/cmd/claude-sync/tui/subview_plugins.go
+++ b/cmd/claude-sync/tui/subview_plugins.go
@@ -446,18 +446,35 @@ func (m PluginBrowser) View() string {
 
 		lines = append(lines, "")
 
-		// Footer info
-		allInstalled := true
+		// Footer info: dynamic selection counts
+		var installed, toAdd, toRemove int
 		for _, item := range m.items {
-			if !item.isHeader && !item.installed {
-				allInstalled = false
-				break
+			if item.isHeader {
+				continue
+			}
+			if item.installed && item.selected {
+				installed++
+			} else if !item.installed && item.selected {
+				toAdd++
+			} else if item.installed && !item.selected {
+				toRemove++
 			}
 		}
-		if allInstalled && len(m.items) > 0 {
-			lines = append(lines, stDim.Render("All plugins are currently installed."))
+		var counts []string
+		if installed > 0 {
+			counts = append(counts, fmt.Sprintf("%d installed", installed))
 		}
-		lines = append(lines, stDim.Render("Subscribe to more via 'Join a shared config'."))
+		if toAdd > 0 {
+			counts = append(counts, fmt.Sprintf("%d to add", toAdd))
+		}
+		if toRemove > 0 {
+			counts = append(counts, fmt.Sprintf("%d to remove", toRemove))
+		}
+		if len(counts) > 0 {
+			lines = append(lines, stDim.Render(strings.Join(counts, ", ")))
+		} else {
+			lines = append(lines, stDim.Render("No plugins selected."))
+		}
 
 		lines = append(lines, "")
 		lines = append(lines, stDim.Render("space toggle  enter confirm  / filter  esc back"))

--- a/cmd/claude-sync/tui/subview_plugins.go
+++ b/cmd/claude-sync/tui/subview_plugins.go
@@ -475,6 +475,7 @@ func (m PluginBrowser) View() string {
 		} else {
 			lines = append(lines, stDim.Render("No plugins selected."))
 		}
+		lines = append(lines, stDim.Render("Subscribe to more via 'Join a shared config'."))
 
 		lines = append(lines, "")
 		lines = append(lines, stDim.Render("space toggle  enter confirm  / filter  esc back"))

--- a/cmd/claude-sync/tui/subview_plugins_test.go
+++ b/cmd/claude-sync/tui/subview_plugins_test.go
@@ -22,7 +22,7 @@ func TestPluginBrowser_ShowsInstalledPlugins(t *testing.T) {
 			{Name: "superpowers", Key: "sp@official", Status: "pinned", PinVersion: "1.2.3", Marketplace: "official"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	view := m.View()
 	assert.Contains(t, view, "beads")
 	assert.Contains(t, view, "superpowers")
@@ -37,7 +37,7 @@ func TestPluginBrowser_GroupsByMarketplace(t *testing.T) {
 			{Name: "superpowers", Key: "sp@mkt2", Marketplace: "mkt2"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	view := m.View()
 	assert.Contains(t, view, "mkt1")
 	assert.Contains(t, view, "mkt2")
@@ -51,7 +51,7 @@ func TestPluginBrowser_CursorSkipsHeaders(t *testing.T) {
 			{Name: "sp", Key: "sp@mkt2", Marketplace: "mkt2"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	// First selectable item should be beads (skip mkt1 header)
 	assert.False(t, m.items[m.cursor].isHeader)
 }
@@ -63,7 +63,7 @@ func TestPluginBrowser_SpaceToggles(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	// Find first non-header item
 	for m.items[m.cursor].isHeader {
 		m.cursor++
@@ -76,7 +76,7 @@ func TestPluginBrowser_SpaceToggles(t *testing.T) {
 
 func TestPluginBrowser_EscCancels(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
 	browser := updated.(PluginBrowser)
 	assert.True(t, browser.cancelled)
@@ -95,7 +95,7 @@ func TestPluginBrowser_FilterMode(t *testing.T) {
 			{Name: "superpowers", Key: "sp@mkt", Marketplace: "mkt"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	// Enter filter mode
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
 	m = updated.(PluginBrowser)
@@ -118,7 +118,7 @@ func TestPluginBrowser_InstalledPluginsPreChecked(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	for _, item := range m.items {
 		if !item.isHeader && item.name == "beads" {
 			assert.True(t, item.installed)
@@ -129,7 +129,7 @@ func TestPluginBrowser_InstalledPluginsPreChecked(t *testing.T) {
 
 func TestPluginBrowser_NoPlugins(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	view := m.View()
 	assert.Contains(t, view, "No plugins")
 }
@@ -143,7 +143,7 @@ func TestPluginBrowser_NavigationJK(t *testing.T) {
 			{Name: "sp", Key: "sp@mkt2", Marketplace: "mkt2"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	// cursor should start on first non-header (beads)
 	require.False(t, m.items[m.cursor].isHeader)
@@ -179,7 +179,7 @@ func TestPluginBrowser_EnterConfirms(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	browser := updated.(PluginBrowser)
 	assert.True(t, browser.confirmed)
@@ -198,7 +198,7 @@ func TestPluginBrowser_EnterWithChanges_TriggersExecution(t *testing.T) {
 			{Name: "hookify", Key: "hookify@mkt", Marketplace: "mkt", Status: "upstream"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	// Deselect first plugin (toggle off an installed plugin)
 	for m.items[m.cursor].isHeader {
@@ -227,7 +227,7 @@ func TestPluginBrowser_IgnoresInputWhileExecuting(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	m.executing = true
 
 	// Key input should be ignored while executing
@@ -239,7 +239,7 @@ func TestPluginBrowser_IgnoresInputWhileExecuting(t *testing.T) {
 
 func TestPluginBrowser_ResultMsg_SetsState(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	updated, cmd := m.Update(pluginBrowserResultMsg{
 		success: true,
@@ -247,14 +247,14 @@ func TestPluginBrowser_ResultMsg_SetsState(t *testing.T) {
 	})
 	browser := updated.(PluginBrowser)
 	assert.True(t, browser.resultDone)
-	assert.True(t, browser.resultSuccess)
+	assert.True(t, browser.resultOk)
 	assert.Equal(t, "Updated plugins: added 1", browser.resultMsg)
 	assert.Nil(t, cmd)
 }
 
 func TestPluginBrowser_ResultMsg_Error(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	updated, _ := m.Update(pluginBrowserResultMsg{
 		success: false,
@@ -262,15 +262,15 @@ func TestPluginBrowser_ResultMsg_Error(t *testing.T) {
 	})
 	browser := updated.(PluginBrowser)
 	assert.True(t, browser.resultDone)
-	assert.False(t, browser.resultSuccess)
+	assert.False(t, browser.resultOk)
 	assert.Equal(t, "config.yaml not found", browser.resultMsg)
 }
 
 func TestPluginBrowser_AfterResult_AnyKeyCloses(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	m.resultDone = true
-	m.resultSuccess = true
+	m.resultOk = true
 	m.resultMsg = "Done"
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -283,9 +283,9 @@ func TestPluginBrowser_AfterResult_AnyKeyCloses(t *testing.T) {
 
 func TestPluginBrowser_ViewShowsResult(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	m.resultDone = true
-	m.resultSuccess = true
+	m.resultOk = true
 	m.resultMsg = "Updated plugins: added 2"
 
 	view := m.View()
@@ -295,7 +295,7 @@ func TestPluginBrowser_ViewShowsResult(t *testing.T) {
 
 func TestPluginBrowser_ViewShowsExecuting(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	m.executing = true
 
 	view := m.View()
@@ -314,7 +314,7 @@ func TestAppModel_RoutesPluginBrowserResultMsg(t *testing.T) {
 	app.height = 40
 
 	// Open plugin browser as subview
-	browser := NewPluginBrowser(state, 80, 40)
+	browser := NewPluginBrowser(state, "", 80, 40)
 	browser.executing = true
 	app.subView = browser
 	app.activeView = viewSubView
@@ -329,7 +329,7 @@ func TestAppModel_RoutesPluginBrowserResultMsg(t *testing.T) {
 	// The subview should have received the result
 	pb := appModel.subView.(PluginBrowser)
 	assert.True(t, pb.resultDone)
-	assert.True(t, pb.resultSuccess)
+	assert.True(t, pb.resultOk)
 	assert.Equal(t, "Updated plugins: excluded 1", pb.resultMsg)
 }
 
@@ -340,7 +340,7 @@ func TestPluginBrowser_FilterModeEscClears(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	// Enter filter mode
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
@@ -368,7 +368,7 @@ func TestPluginBrowser_FilterBackspaceDeletesChar(t *testing.T) {
 			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 
 	// Enter filter mode and type "abc"
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
@@ -392,7 +392,7 @@ func TestPluginBrowser_ShowsVersionForPinned(t *testing.T) {
 			{Name: "superpowers", Key: "sp@official", Status: "pinned", PinVersion: "1.2.3", Marketplace: "official"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	view := m.View()
 	assert.Contains(t, view, "v1.2.3")
 }
@@ -406,7 +406,7 @@ func TestPluginBrowser_ShowsStatusLabel(t *testing.T) {
 			{Name: "fork", Key: "fork@local", Status: "forked", Marketplace: "local"},
 		},
 	}
-	m := NewPluginBrowser(state, 70, 30)
+	m := NewPluginBrowser(state, "", 70, 30)
 	view := m.View()
 	assert.Contains(t, view, "upstream")
 	assert.Contains(t, view, "pinned")
@@ -467,6 +467,13 @@ plugins:
 	assert.NotContains(t, cfg.Upstream, "beads@mkt", "beads should be removed from upstream")
 	assert.Contains(t, cfg.Excluded, "beads@mkt", "beads should be in excluded")
 	assert.Contains(t, cfg.Upstream, "hookify@mkt", "hookify should remain in upstream")
+
+	// Verify a git commit was created
+	logCmd := exec.Command("git", "log", "--oneline", "-1")
+	logCmd.Dir = dir
+	logOut, err := logCmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(logOut), "Update plugins: excluded 1")
 }
 
 func TestApplyPluginSelections_AddsPlugin(t *testing.T) {
@@ -491,6 +498,46 @@ plugins:
 	require.NoError(t, err)
 	assert.Contains(t, cfg.Upstream, "beads@mkt", "beads should be added to upstream")
 	assert.NotContains(t, cfg.Excluded, "beads@mkt", "beads should be removed from excluded")
+
+	// Verify a git commit was created
+	logCmd := exec.Command("git", "log", "--oneline", "-1")
+	logCmd.Dir = dir
+	logOut, err := logCmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(logOut), "Update plugins: added 1")
+}
+
+func TestApplyPluginSelections_AddAndRemoveSimultaneously(t *testing.T) {
+	cfgYAML := `version: "2"
+plugins:
+  upstream:
+    - old@mkt
+  excluded:
+    - new@mkt
+`
+	dir := initTestGitRepo(t, cfgYAML)
+
+	cmd := applyPluginSelections(dir, []string{"new@mkt"}, []string{"old@mkt"})
+	result := cmd()
+	msg, ok := result.(pluginBrowserResultMsg)
+	require.True(t, ok)
+	assert.True(t, msg.success, "expected success but got: %v", msg.err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, err)
+	cfg, err := config.Parse(data)
+	require.NoError(t, err)
+	assert.Contains(t, cfg.Upstream, "new@mkt", "new should be added to upstream")
+	assert.NotContains(t, cfg.Excluded, "new@mkt", "new should be removed from excluded")
+	assert.Contains(t, cfg.Excluded, "old@mkt", "old should be in excluded")
+	assert.NotContains(t, cfg.Upstream, "old@mkt", "old should be removed from upstream")
+
+	// Verify commit message includes both operations
+	logCmd := exec.Command("git", "log", "--oneline", "-1")
+	logCmd.Dir = dir
+	logOut, err := logCmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(logOut), "added 1, excluded 1")
 }
 
 func TestApplyPluginSelections_InvalidConfig(t *testing.T) {
@@ -502,6 +549,16 @@ func TestApplyPluginSelections_InvalidConfig(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, msg.success)
 	assert.NotNil(t, msg.err)
+	assert.Equal(t, "Could not read config.yaml", msg.message)
+}
+
+func TestApplyPluginSelections_EmptySyncDir(t *testing.T) {
+	cmd := applyPluginSelections("", []string{"foo@bar"}, nil)
+	result := cmd()
+	msg, ok := result.(pluginBrowserResultMsg)
+	require.True(t, ok)
+	assert.False(t, msg.success)
+	assert.Equal(t, "Sync directory is not configured", msg.message)
 }
 
 // --- AppModel integration test ---
@@ -516,6 +573,7 @@ func TestAppModel_BrowsePluginsIntent_OpensPluginBrowser(t *testing.T) {
 	m := NewAppModel(state)
 	m.width = 80
 	m.height = 40
+	m.syncDir = "/test/sync/dir"
 	m.activeView = viewMain
 	m.recommendations = buildRecommendations(m.state)
 	m.intents = buildIntents(m.state)
@@ -535,10 +593,14 @@ func TestAppModel_BrowsePluginsIntent_OpensPluginBrowser(t *testing.T) {
 	app := updated.(AppModel)
 
 	assert.Equal(t, viewSubView, app.activeView)
-	assert.NotNil(t, app.subView)
+	require.NotNil(t, app.subView)
 
 	// The sub-view should render plugin browser content
 	view := app.subView.View()
 	assert.Contains(t, view, "Add or discover new plugins")
 	assert.Contains(t, view, "beads")
+
+	// Verify syncDir was propagated through the constructor
+	pb := app.subView.(PluginBrowser)
+	assert.Equal(t, "/test/sync/dir", pb.syncDir)
 }

--- a/cmd/claude-sync/tui/subview_plugins_test.go
+++ b/cmd/claude-sync/tui/subview_plugins_test.go
@@ -1,10 +1,15 @@
 package tui
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/ruminaider/claude-sync/internal/commands"
+	"github.com/ruminaider/claude-sync/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -185,6 +190,149 @@ func TestPluginBrowser_EnterConfirms(t *testing.T) {
 	assert.False(t, closeMsg.refreshState) // no changes, so no refresh
 }
 
+func TestPluginBrowser_EnterWithChanges_TriggersExecution(t *testing.T) {
+	state := commands.MenuState{
+		ConfigExists: true,
+		Plugins: []commands.PluginInfo{
+			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
+			{Name: "hookify", Key: "hookify@mkt", Marketplace: "mkt", Status: "upstream"},
+		},
+	}
+	m := NewPluginBrowser(state, 70, 30)
+
+	// Deselect first plugin (toggle off an installed plugin)
+	for m.items[m.cursor].isHeader {
+		m.cursor++
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" ")})
+	m = updated.(PluginBrowser)
+	assert.False(t, m.items[m.cursor].selected)
+
+	// Press Enter: should trigger execution, not immediate close
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	browser := updated.(PluginBrowser)
+	assert.True(t, browser.confirmed)
+	assert.True(t, browser.executing)
+	assert.Equal(t, []string{"beads@mkt"}, browser.removedSelections)
+	require.NotNil(t, cmd)
+
+	// The command should NOT return subViewCloseMsg (it returns pluginBrowserResultMsg)
+	// We can't run it without a real git repo, but we can verify the model state
+}
+
+func TestPluginBrowser_IgnoresInputWhileExecuting(t *testing.T) {
+	state := commands.MenuState{
+		ConfigExists: true,
+		Plugins: []commands.PluginInfo{
+			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
+		},
+	}
+	m := NewPluginBrowser(state, 70, 30)
+	m.executing = true
+
+	// Key input should be ignored while executing
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	browser := updated.(PluginBrowser)
+	assert.False(t, browser.cancelled) // should NOT have cancelled
+	assert.Nil(t, cmd)
+}
+
+func TestPluginBrowser_ResultMsg_SetsState(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	m := NewPluginBrowser(state, 70, 30)
+
+	updated, cmd := m.Update(pluginBrowserResultMsg{
+		success: true,
+		message: "Updated plugins: added 1",
+	})
+	browser := updated.(PluginBrowser)
+	assert.True(t, browser.resultDone)
+	assert.True(t, browser.resultSuccess)
+	assert.Equal(t, "Updated plugins: added 1", browser.resultMsg)
+	assert.Nil(t, cmd)
+}
+
+func TestPluginBrowser_ResultMsg_Error(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	m := NewPluginBrowser(state, 70, 30)
+
+	updated, _ := m.Update(pluginBrowserResultMsg{
+		success: false,
+		err:     fmt.Errorf("config.yaml not found"),
+	})
+	browser := updated.(PluginBrowser)
+	assert.True(t, browser.resultDone)
+	assert.False(t, browser.resultSuccess)
+	assert.Equal(t, "config.yaml not found", browser.resultMsg)
+}
+
+func TestPluginBrowser_AfterResult_AnyKeyCloses(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	m := NewPluginBrowser(state, 70, 30)
+	m.resultDone = true
+	m.resultSuccess = true
+	m.resultMsg = "Done"
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd()
+	closeMsg, ok := msg.(subViewCloseMsg)
+	assert.True(t, ok)
+	assert.True(t, closeMsg.refreshState)
+}
+
+func TestPluginBrowser_ViewShowsResult(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	m := NewPluginBrowser(state, 70, 30)
+	m.resultDone = true
+	m.resultSuccess = true
+	m.resultMsg = "Updated plugins: added 2"
+
+	view := m.View()
+	assert.Contains(t, view, "Updated plugins: added 2")
+	assert.Contains(t, view, "Press any key")
+}
+
+func TestPluginBrowser_ViewShowsExecuting(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	m := NewPluginBrowser(state, 70, 30)
+	m.executing = true
+
+	view := m.View()
+	assert.Contains(t, view, "Applying plugin changes")
+}
+
+func TestAppModel_RoutesPluginBrowserResultMsg(t *testing.T) {
+	state := commands.MenuState{
+		ConfigExists: true,
+		Plugins: []commands.PluginInfo{
+			{Name: "beads", Key: "beads@mkt", Status: "upstream", Marketplace: "mkt"},
+		},
+	}
+	app := NewAppModel(state)
+	app.width = 80
+	app.height = 40
+
+	// Open plugin browser as subview
+	browser := NewPluginBrowser(state, 80, 40)
+	browser.executing = true
+	app.subView = browser
+	app.activeView = viewSubView
+
+	// Route a pluginBrowserResultMsg to the subview
+	updated, _ := app.Update(pluginBrowserResultMsg{
+		success: true,
+		message: "Updated plugins: excluded 1",
+	})
+	appModel := updated.(AppModel)
+
+	// The subview should have received the result
+	pb := appModel.subView.(PluginBrowser)
+	assert.True(t, pb.resultDone)
+	assert.True(t, pb.resultSuccess)
+	assert.Equal(t, "Updated plugins: excluded 1", pb.resultMsg)
+}
+
 func TestPluginBrowser_FilterModeEscClears(t *testing.T) {
 	state := commands.MenuState{
 		ConfigExists: true,
@@ -263,6 +411,97 @@ func TestPluginBrowser_ShowsStatusLabel(t *testing.T) {
 	assert.Contains(t, view, "upstream")
 	assert.Contains(t, view, "pinned")
 	assert.Contains(t, view, "forked")
+}
+
+// --- Integration tests for applyPluginSelections ---
+
+// initTestGitRepo creates a temp dir with a git repo containing a config.yaml.
+func initTestGitRepo(t *testing.T, cfgContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		require.NoError(t, cmd.Run())
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfgContent), 0644))
+
+	gitAdd := exec.Command("git", "add", "config.yaml")
+	gitAdd.Dir = dir
+	require.NoError(t, gitAdd.Run())
+
+	gitCommit := exec.Command("git", "commit", "-m", "initial")
+	gitCommit.Dir = dir
+	require.NoError(t, gitCommit.Run())
+
+	return dir
+}
+
+func TestApplyPluginSelections_ExcludesPlugin(t *testing.T) {
+	cfgYAML := `version: "2"
+plugins:
+  upstream:
+    - beads@mkt
+    - hookify@mkt
+`
+	dir := initTestGitRepo(t, cfgYAML)
+
+	cmd := applyPluginSelections(dir, nil, []string{"beads@mkt"})
+	result := cmd()
+	msg, ok := result.(pluginBrowserResultMsg)
+	require.True(t, ok)
+	assert.True(t, msg.success, "expected success but got: %v", msg.err)
+
+	// Read back config and verify
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, err)
+	cfg, err := config.Parse(data)
+	require.NoError(t, err)
+	assert.NotContains(t, cfg.Upstream, "beads@mkt", "beads should be removed from upstream")
+	assert.Contains(t, cfg.Excluded, "beads@mkt", "beads should be in excluded")
+	assert.Contains(t, cfg.Upstream, "hookify@mkt", "hookify should remain in upstream")
+}
+
+func TestApplyPluginSelections_AddsPlugin(t *testing.T) {
+	cfgYAML := `version: "2"
+plugins:
+  upstream:
+    - hookify@mkt
+  excluded:
+    - beads@mkt
+`
+	dir := initTestGitRepo(t, cfgYAML)
+
+	cmd := applyPluginSelections(dir, []string{"beads@mkt"}, nil)
+	result := cmd()
+	msg, ok := result.(pluginBrowserResultMsg)
+	require.True(t, ok)
+	assert.True(t, msg.success, "expected success but got: %v", msg.err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, err)
+	cfg, err := config.Parse(data)
+	require.NoError(t, err)
+	assert.Contains(t, cfg.Upstream, "beads@mkt", "beads should be added to upstream")
+	assert.NotContains(t, cfg.Excluded, "beads@mkt", "beads should be removed from excluded")
+}
+
+func TestApplyPluginSelections_InvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	// No config.yaml at all
+	cmd := applyPluginSelections(dir, []string{"foo@bar"}, nil)
+	result := cmd()
+	msg, ok := result.(pluginBrowserResultMsg)
+	require.True(t, ok)
+	assert.False(t, msg.success)
+	assert.NotNil(t, msg.err)
 }
 
 // --- AppModel integration test ---

--- a/cmd/claude-sync/tui/subview_plugins_test.go
+++ b/cmd/claude-sync/tui/subview_plugins_test.go
@@ -413,6 +413,32 @@ func TestPluginBrowser_ShowsStatusLabel(t *testing.T) {
 	assert.Contains(t, view, "forked")
 }
 
+func TestPluginBrowser_FooterShowsDynamicCounts(t *testing.T) {
+	state := commands.MenuState{
+		ConfigExists: true,
+		Plugins: []commands.PluginInfo{
+			{Name: "beads", Key: "beads@mkt", Marketplace: "mkt", Status: "upstream"},
+			{Name: "hookify", Key: "hookify@mkt", Marketplace: "mkt", Status: "upstream"},
+		},
+	}
+	m := NewPluginBrowser(state, "", 70, 30)
+
+	// Initial state: both installed and selected
+	view := m.View()
+	assert.Contains(t, view, "2 installed")
+
+	// Deselect one plugin (toggle off beads)
+	for m.items[m.cursor].isHeader {
+		m.cursor++
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" ")})
+	m = updated.(PluginBrowser)
+
+	view = m.View()
+	assert.Contains(t, view, "1 installed")
+	assert.Contains(t, view, "1 to remove")
+}
+
 // --- Integration tests for applyPluginSelections ---
 
 // initTestGitRepo creates a temp dir with a git repo containing a config.yaml.

--- a/cmd/claude-sync/tui/subview_subscribe_test.go
+++ b/cmd/claude-sync/tui/subview_subscribe_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ruminaider/claude-sync/internal/commands"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -236,6 +237,35 @@ func TestSubscribeFlow_WindowResize(t *testing.T) {
 	assert.Equal(t, 120, flow.width)
 	assert.Equal(t, 50, flow.height)
 	assert.Nil(t, cmd)
+}
+
+// --- AppModel routing test ---
+
+func TestAppModel_RoutesSubscribeResultMsg(t *testing.T) {
+	state := commands.MenuState{ConfigExists: true}
+	app := NewAppModel(state)
+	app.width = 80
+	app.height = 40
+
+	// Open subscribe flow as subview
+	sf := NewSubscribeFlow(80, 40)
+	sf.executing = true
+	app.subView = sf
+	app.activeView = viewSubView
+
+	// Route a subscribeResultMsg through AppModel
+	updated, _ := app.Update(subscribeResultMsg{
+		success: true,
+		message: "Subscribed to user/config-repo",
+	})
+	appModel := updated.(AppModel)
+
+	// The subview should have received the result
+	flow := appModel.subView.(*SubscribeFlow)
+	assert.True(t, flow.resultDone, "subscribeResultMsg should reach the subview")
+	assert.True(t, flow.resultOk)
+	assert.False(t, flow.executing, "executing should be cleared")
+	assert.Contains(t, flow.resultMsg, "Subscribed to user/config-repo")
 }
 
 // resolveResultMsg tests live in result_state_test.go.

--- a/internal/commands/approve.go
+++ b/internal/commands/approve.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ruminaider/claude-sync/internal/approval"
 	"github.com/ruminaider/claude-sync/internal/claudecode"
+	"github.com/ruminaider/claude-sync/internal/sliceutil"
 )
 
 // ApproveResult holds the result of applying pending changes.
@@ -45,8 +46,8 @@ func Approve(claudeDir, syncDir string) (*ApproveResult, error) {
 		}
 
 		// Additive merge.
-		mergedAllow := appendUniqueApprove(existingPerms.Allow, pending.Permissions.Allow)
-		mergedDeny := appendUniqueApprove(existingPerms.Deny, pending.Permissions.Deny)
+		mergedAllow := sliceutil.AppendUnique(existingPerms.Allow, pending.Permissions.Allow)
+		mergedDeny := sliceutil.AppendUnique(existingPerms.Deny, pending.Permissions.Deny)
 
 		permData, err := json.Marshal(map[string]any{
 			"allow": mergedAllow,
@@ -113,19 +114,3 @@ func Approve(claudeDir, syncDir string) (*ApproveResult, error) {
 	return result, nil
 }
 
-// appendUniqueApprove appends items from add to base without duplicates.
-func appendUniqueApprove(base, add []string) []string {
-	seen := make(map[string]bool, len(base))
-	for _, s := range base {
-		seen[s] = true
-	}
-	result := make([]string, len(base))
-	copy(result, base)
-	for _, s := range add {
-		if !seen[s] {
-			seen[s] = true
-			result = append(result, s)
-		}
-	}
-	return result
-}

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ruminaider/claude-sync/internal/approval"
 	"github.com/ruminaider/claude-sync/internal/bundled"
+	"github.com/ruminaider/claude-sync/internal/sliceutil"
 	"github.com/ruminaider/claude-sync/internal/claudecode"
 	"github.com/ruminaider/claude-sync/internal/claudemd"
 	"github.com/ruminaider/claude-sync/internal/config"
@@ -956,8 +957,8 @@ func applyPermissions(claudeDir string, perms config.Permissions) error {
 		json.Unmarshal(permRaw, &existingPerms)
 	}
 
-	mergedAllow := appendUniqueStrings(existingPerms.Allow, perms.Allow)
-	mergedDeny := appendUniqueStrings(existingPerms.Deny, perms.Deny)
+	mergedAllow := sliceutil.AppendUnique(existingPerms.Allow, perms.Allow)
+	mergedDeny := sliceutil.AppendUnique(existingPerms.Deny, perms.Deny)
 
 	permData, err := json.Marshal(map[string]any{
 		"allow": mergedAllow,
@@ -1082,22 +1083,6 @@ func restoreCommandsSkills(claudeDir, syncDir string, commandKeys, skillKeys []s
 	return
 }
 
-// appendUniqueStrings appends items from add to base without duplicates.
-func appendUniqueStrings(base, add []string) []string {
-	seen := make(map[string]bool, len(base))
-	for _, s := range base {
-		seen[s] = true
-	}
-	result := make([]string, len(base))
-	copy(result, base)
-	for _, s := range add {
-		if !seen[s] {
-			seen[s] = true
-			result = append(result, s)
-		}
-	}
-	return result
-}
 
 // detectStalePlugins returns synced plugin keys whose cache is out of date.
 // For directory-based marketplaces, it compares content hashes of the source

--- a/internal/profiles/profile.go
+++ b/internal/profiles/profile.go
@@ -591,8 +591,6 @@ func MergePermissions(base config.Permissions, profile Profile) config.Permissio
 	}
 }
 
-// appendUnique appends items from add to base, skipping duplicates.
-
 // MergeClaudeMD starts with base includes, adds profile.ClaudeMD.Add (no
 // duplicates), then removes profile.ClaudeMD.Remove. Same pattern as
 // MergePlugins.

--- a/internal/profiles/profile.go
+++ b/internal/profiles/profile.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ruminaider/claude-sync/internal/config"
+	"github.com/ruminaider/claude-sync/internal/sliceutil"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -585,30 +586,12 @@ func MergeHooks(base map[string]json.RawMessage, profile Profile) map[string]jso
 // without duplicates.
 func MergePermissions(base config.Permissions, profile Profile) config.Permissions {
 	return config.Permissions{
-		Allow: appendUnique(base.Allow, profile.Permissions.AddAllow),
-		Deny:  appendUnique(base.Deny, profile.Permissions.AddDeny),
+		Allow: sliceutil.AppendUnique(base.Allow, profile.Permissions.AddAllow),
+		Deny:  sliceutil.AppendUnique(base.Deny, profile.Permissions.AddDeny),
 	}
 }
 
 // appendUnique appends items from add to base, skipping duplicates.
-func appendUnique(base, add []string) []string {
-	if len(add) == 0 {
-		return base
-	}
-	seen := make(map[string]bool, len(base))
-	for _, s := range base {
-		seen[s] = true
-	}
-	result := make([]string, len(base))
-	copy(result, base)
-	for _, s := range add {
-		if !seen[s] {
-			seen[s] = true
-			result = append(result, s)
-		}
-	}
-	return result
-}
 
 // MergeClaudeMD starts with base includes, adds profile.ClaudeMD.Add (no
 // duplicates), then removes profile.ClaudeMD.Remove. Same pattern as

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,40 @@
+package sliceutil
+
+// AppendUnique appends items from add to base, skipping duplicates.
+// Returns a new slice; does not modify the original.
+func AppendUnique(base, add []string) []string {
+	if len(add) == 0 {
+		return base
+	}
+	seen := make(map[string]bool, len(base))
+	for _, s := range base {
+		seen[s] = true
+	}
+	result := make([]string, len(base))
+	copy(result, base)
+	for _, s := range add {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// RemoveAll returns base with all items in remove filtered out.
+func RemoveAll(base, remove []string) []string {
+	if len(remove) == 0 {
+		return base
+	}
+	drop := make(map[string]bool, len(remove))
+	for _, s := range remove {
+		drop[s] = true
+	}
+	var result []string
+	for _, s := range base {
+		if !drop[s] {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,22 @@
+package sliceutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendUnique(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, AppendUnique([]string{"a", "b"}, []string{"b", "c"}))
+	assert.Equal(t, []string{"a"}, AppendUnique([]string{"a"}, []string{"a"}))
+	assert.Equal(t, []string{"a"}, AppendUnique([]string{"a"}, nil))
+	assert.Equal(t, []string{"a"}, AppendUnique(nil, []string{"a"}))
+	assert.Nil(t, AppendUnique(nil, nil))
+}
+
+func TestRemoveAll(t *testing.T) {
+	assert.Equal(t, []string{"a"}, RemoveAll([]string{"a", "b", "c"}, []string{"b", "c"}))
+	assert.Nil(t, RemoveAll([]string{"a"}, []string{"a"}))
+	assert.Equal(t, []string{"a", "b"}, RemoveAll([]string{"a", "b"}, nil))
+	assert.Nil(t, RemoveAll(nil, []string{"a"}))
+}


### PR DESCRIPTION
## Summary

Closes #57.

- Wire `PluginBrowser` into the same async result-message pattern used by `ProfilePicker`, `ApproveView`, and other TUI subviews
- On confirm with changes, `applyPluginSelections` modifies `config.yaml` (adds to `upstream` or `excluded`), commits, and reports success/failure back to the browser
- Route `pluginBrowserResultMsg` through `AppModel` so the subview receives the result and displays it before closing
- Add 10 new tests: 7 unit tests for model behavior, 3 integration tests with real git repos

## Test plan

- [x] All 81 existing + new TUI tests pass (`go test ./cmd/claude-sync/tui/`)
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual: run `claude-sync`, open plugin browser, toggle a plugin, press Enter, verify config.yaml is updated
- [ ] Manual: confirm that cancelling (Esc) still works without changes
- [ ] Manual: confirm that confirming with no changes closes immediately