### PR TITLE
refactor: polish update notification code after merge

### DIFF
--- a/cmd/claude-sync/cmd_pull.go
+++ b/cmd/claude-sync/cmd_pull.go
@@ -175,7 +175,8 @@ var pullCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "  - %s\n", c.Description)
 				}
 			}
-			// Output version check for session-start hook to parse.
+			// Protocol: "UPDATE_AVAILABLE:current:latest" on stderr.
+			// Parsed by plugin/hooks/session-start.sh; keep in sync.
 			if result.UpdateAvailable {
 				fmt.Fprintf(os.Stderr, "UPDATE_AVAILABLE:%s:%s\n", result.CurrentVersion, result.LatestVersion)
 			}

--- a/cmd/claude-sync/tui/app.go
+++ b/cmd/claude-sync/tui/app.go
@@ -410,11 +410,22 @@ func (m AppModel) viewMain() string {
 	recs := filterRecommendations(m.recommendations, m.filterText)
 	intents := filterIntents(m.intents, m.filterText)
 
-	return renderMainScreen(m.state, recs, intents,
-		m.actionCursor, m.width, m.height, m.version,
-		m.executing, m.executingActionID, m.executionResults,
-		m.filterMode, m.filterText,
-		m.updateAvailable, m.latestVersion)
+	return renderMainScreen(MainScreenParams{
+		State:             m.state,
+		Recs:              recs,
+		Intents:           intents,
+		Cursor:            m.actionCursor,
+		Width:             m.width,
+		Height:            m.height,
+		Version:           m.version,
+		Executing:         m.executing,
+		ExecutingActionID: m.executingActionID,
+		Results:           m.executionResults,
+		FilterMode:        m.filterMode,
+		FilterText:        m.filterText,
+		UpdateAvailable:   m.updateAvailable,
+		LatestVersion:     m.latestVersion,
+	})
 }
 
 func (m AppModel) viewMainHelp() string {

--- a/cmd/claude-sync/tui/dashboard.go
+++ b/cmd/claude-sync/tui/dashboard.go
@@ -95,15 +95,29 @@ func renderUpdateBanner(currentVersion, latestVersion string, width int) string 
 	return borderStyle.Render(content)
 }
 
-// renderMainScreen renders the unified main screen with summary at top,
-// recommendations, and intents — all in one view.
-func renderMainScreen(state commands.MenuState, recs []recommendation, intents []intent,
-	cursor int, width, height int, version string,
-	executing bool, executingActionID string, results map[string]actionResultMsg,
-	filterMode bool, filterText string,
-	updateAvailable bool, latestVersion string) string {
+// MainScreenParams groups the arguments for renderMainScreen to avoid
+// positional-parameter sprawl (previously 14 args with 4 bare bools).
+type MainScreenParams struct {
+	State             commands.MenuState
+	Recs              []recommendation
+	Intents           []intent
+	Cursor            int
+	Width, Height     int
+	Version           string
+	Executing         bool
+	ExecutingActionID string
+	Results           map[string]actionResultMsg
+	FilterMode        bool
+	FilterText        string
+	UpdateAvailable   bool
+	LatestVersion     string
+}
 
-	maxWidth, innerWidth := clampWidth(width)
+// renderMainScreen renders the unified main screen with summary at top,
+// recommendations, and intents in one view.
+func renderMainScreen(p MainScreenParams) string {
+
+	maxWidth, innerWidth := clampWidth(p.Width)
 
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorBlue)
 	dimStyle := lipgloss.NewStyle().Foreground(colorOverlay0)
@@ -111,35 +125,35 @@ func renderMainScreen(state commands.MenuState, recs []recommendation, intents [
 	var sections []string
 
 	// --- Header ---
-	sections = append(sections, titleStyle.Render("claude-sync")+" "+dimStyle.Render("v"+version))
+	sections = append(sections, titleStyle.Render("claude-sync")+" "+dimStyle.Render("v"+p.Version))
 
-	if updateAvailable {
-		sections = append(sections, renderUpdateBanner(version, latestVersion, maxWidth))
+	if p.UpdateAvailable {
+		sections = append(sections, renderUpdateBanner(p.Version, p.LatestVersion, maxWidth))
 	}
 
 	// --- Summary ---
-	sections = append(sections, renderSummary(state, version))
+	sections = append(sections, renderSummary(p.State, p.Version))
 
 	// --- Filter bar (when active) ---
-	if filterMode || filterText != "" {
+	if p.FilterMode || p.FilterText != "" {
 		filterStyle := lipgloss.NewStyle().Foreground(colorBlue)
 		cursorChar := ""
-		if filterMode {
+		if p.FilterMode {
 			cursorChar = "\u2588" // block cursor
 		}
-		sections = append(sections, filterStyle.Render("/ "+filterText+cursorChar))
+		sections = append(sections, filterStyle.Render("/ "+p.FilterText+cursorChar))
 	}
 
 	// --- No results message ---
-	if len(recs) == 0 && len(intents) == 0 && filterText != "" {
+	if len(p.Recs) == 0 && len(p.Intents) == 0 && p.FilterText != "" {
 		noMatchStyle := lipgloss.NewStyle().Foreground(colorSubtext0)
 		sections = append(sections, noMatchStyle.Render("No matching actions"))
 	} else {
 		// --- Needs attention / Status section ---
-		sections = append(sections, renderRecsSectionWithState(recs, cursor, innerWidth, executing, executingActionID, results))
+		sections = append(sections, renderRecsSectionWithState(p.Recs, p.Cursor, innerWidth, p.Executing, p.ExecutingActionID, p.Results))
 
 		// --- Grouped intent sections (Sync, Plugins, Config) ---
-		sections = append(sections, renderIntentsSectionWithState(intents, len(recs), cursor, innerWidth, executing, executingActionID, results))
+		sections = append(sections, renderIntentsSectionWithState(p.Intents, len(p.Recs), p.Cursor, innerWidth, p.Executing, p.ExecutingActionID, p.Results))
 	}
 
 	// --- Footer ---

--- a/cmd/claude-sync/tui/dashboard_test.go
+++ b/cmd/claude-sync/tui/dashboard_test.go
@@ -127,7 +127,9 @@ func TestRenderSummary_ProjectWithProfile(t *testing.T) {
 func TestRenderMainScreen_ShowsVersion(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
 	intents := buildIntents(state)
-	view := renderMainScreen(state, nil, intents, 0, 70, 30, "0.7.0", false, "", nil, false, "", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 70, Height: 30, Version: "0.7.0",
+	})
 	assert.Contains(t, view, "0.7.0")
 }
 
@@ -138,7 +140,9 @@ func TestRenderMainScreen_ShowsSummaryAndActions(t *testing.T) {
 	}
 	recs := buildRecommendations(state)
 	intents := buildIntents(state)
-	view := renderMainScreen(state, recs, intents, 0, 70, 30, "0.7.0", false, "", nil, false, "", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Recs: recs, Intents: intents, Width: 70, Height: 30, Version: "0.7.0",
+	})
 	// Summary
 	assert.Contains(t, view, "User config")
 	assert.Contains(t, view, "user/repo")
@@ -151,14 +155,18 @@ func TestRenderMainScreen_ShowsSummaryAndActions(t *testing.T) {
 func TestRenderMainScreen_NothingToRecommend(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
 	intents := buildIntents(state)
-	view := renderMainScreen(state, nil, intents, 0, 70, 30, "0.7.0", false, "", nil, false, "", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 70, Height: 30, Version: "0.7.0",
+	})
 	assert.Contains(t, view, "Everything looks good")
 }
 
 func TestRenderMainScreen_Footer(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
 	intents := buildIntents(state)
-	view := renderMainScreen(state, nil, intents, 0, 70, 30, "0.7.0", false, "", nil, false, "", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 70, Height: 30, Version: "0.7.0",
+	})
 	assert.Contains(t, view, "filter")
 	assert.Contains(t, view, "help")
 	assert.Contains(t, view, "quit")
@@ -167,13 +175,19 @@ func TestRenderMainScreen_Footer(t *testing.T) {
 func TestRenderMainScreen_FilterBar(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
 	intents := buildIntents(state)
-	view := renderMainScreen(state, nil, intents, 0, 70, 30, "0.7.0", false, "", nil, true, "plug", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 70, Height: 30, Version: "0.7.0",
+		FilterMode: true, FilterText: "plug",
+	})
 	assert.Contains(t, view, "plug")
 }
 
 func TestRenderMainScreen_NoFilterResults(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
-	view := renderMainScreen(state, nil, nil, 0, 70, 30, "0.7.0", false, "", nil, false, "zzz", false, "")
+	view := renderMainScreen(MainScreenParams{
+		State: state, Width: 70, Height: 30, Version: "0.7.0",
+		FilterText: "zzz",
+	})
 	assert.Contains(t, view, "No matching actions")
 }
 
@@ -203,11 +217,14 @@ func TestRenderMainScreen_BannerPresence(t *testing.T) {
 	state := commands.MenuState{ConfigExists: true}
 	intents := buildIntents(state)
 
-	withBanner := renderMainScreen(state, nil, intents, 0, 80, 40, "0.11.0",
-		false, "", nil, false, "", true, "0.12.0")
+	withBanner := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 80, Height: 40, Version: "0.11.0",
+		UpdateAvailable: true, LatestVersion: "0.12.0",
+	})
 	assert.Contains(t, withBanner, "UPDATE AVAILABLE")
 
-	withoutBanner := renderMainScreen(state, nil, intents, 0, 80, 40, "0.11.0",
-		false, "", nil, false, "", false, "")
+	withoutBanner := renderMainScreen(MainScreenParams{
+		State: state, Intents: intents, Width: 80, Height: 40, Version: "0.11.0",
+	})
 	assert.NotContains(t, withoutBanner, "UPDATE AVAILABLE")
 }

--- a/cmd/claude-sync/tui/styles.go
+++ b/cmd/claude-sync/tui/styles.go
@@ -32,11 +32,14 @@ var (
 	colorMaroon   = lipgloss.Color(flavor.Maroon().Hex)
 )
 
-// Catppuccin Latte colors (used for update banner contrast on Mocha background)
+// Catppuccin Latte palette: intentionally different from Mocha above so the
+// update banner stands out visually against the dark Mocha background.
+var latteFlavor = catppuccin.Latte
+
 var (
-	colorLatteMauve    = lipgloss.Color("#8839ef")
-	colorLatteLavender = lipgloss.Color("#7287fd")
-	colorLattePeach    = lipgloss.Color("#fe640b")
+	colorLatteMauve    = lipgloss.Color(latteFlavor.Mauve().Hex)
+	colorLatteLavender = lipgloss.Color(latteFlavor.Lavender().Hex)
+	colorLattePeach    = lipgloss.Color(latteFlavor.Peach().Hex)
 )
 
 // ProfileTheme holds the accent color for a profile tab.

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -54,10 +54,7 @@ type PullResult struct {
 	PendingHighRisk            []approval.Change
 	Updated                    []string // plugins refreshed due to version mismatch
 	UpdateFailed               []string // plugins that failed to refresh
-	// Version check results
-	UpdateAvailable            bool     // true if a newer claude-sync binary exists
-	LatestVersion              string   // latest available version (empty if check failed)
-	CurrentVersion             string   // currently installed version
+	VersionCheckResult                  // embedded: UpdateAvailable, LatestVersion, CurrentVersion
 	UndefinedMarketplaces      map[string][]string // marketplace name -> plugin names referencing it
 	ProjectSettingsApplied     bool
 	ProjectUnmanagedDetected   bool     // CWD has settings.local.json but no .claude-sync.yaml
@@ -328,38 +325,19 @@ func PullWithOptions(opts PullOptions) (*PullResult, error) {
 		result.Updated, result.UpdateFailed = refreshStalePlugins(claudeDir, stale, installed, quiet)
 	}
 
-	// Check for claude-sync binary updates.
 	if opts.Version != "" && opts.SyncDir != "" {
-		vc := CheckForUpdate(opts.SyncDir, opts.Version)
-		result.UpdateAvailable = vc.UpdateAvailable
-		result.LatestVersion = vc.LatestVersion
-		result.CurrentVersion = vc.CurrentVersion
+		result.VersionCheckResult = CheckForUpdate(opts.SyncDir, opts.Version)
 	}
 
-	// Full plugin refresh (absorbed from update command).
-	// This covers upstream and forked plugins that stale detection may miss.
+	// Full plugin refresh, skipping plugins already refreshed by stale detection.
 	if opts.SyncDir != "" {
-		updateResult, updateErr := updateCheck(claudeDir, opts.SyncDir)
-		if updateErr == nil && updateResult.hasUpdates() {
-			upstreamKeys := make([]string, 0, len(updateResult.UpstreamPlugins))
-			for _, p := range updateResult.UpstreamPlugins {
-				upstreamKeys = append(upstreamKeys, p.Key)
-			}
-			if len(upstreamKeys) > 0 {
-				installed, failed := updateApply(claudeDir, opts.SyncDir, upstreamKeys, quiet)
-				result.Updated = append(result.Updated, installed...)
-				result.UpdateFailed = append(result.UpdateFailed, failed...)
-			}
-			if len(updateResult.ForkedPlugins) > 0 {
-				forkNames := make([]string, 0, len(updateResult.ForkedPlugins))
-				for _, f := range updateResult.ForkedPlugins {
-					forkNames = append(forkNames, f.Name)
-				}
-				installed, failed := updateForkedPlugins(claudeDir, opts.SyncDir, forkNames, quiet)
-				result.Updated = append(result.Updated, installed...)
-				result.UpdateFailed = append(result.UpdateFailed, failed...)
-			}
+		skipKeys := make(map[string]bool, len(result.Updated))
+		for _, key := range result.Updated {
+			skipKeys[key] = true
 		}
+		refreshed, refreshFailed := runFullPluginRefresh(claudeDir, opts.SyncDir, quiet, skipKeys)
+		result.Updated = append(result.Updated, refreshed...)
+		result.UpdateFailed = append(result.UpdateFailed, refreshFailed...)
 	}
 
 	// Self-heal enabledPlugins lost during failed install cycles.

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -98,6 +98,40 @@ func updateCheck(claudeDir, syncDir string) (*UpdateResult, error) {
 	return result, nil
 }
 
+// runFullPluginRefresh performs a full plugin refresh for all upstream and forked
+// plugins. skipKeys contains plugin keys already refreshed (e.g., by stale detection)
+// to avoid double-reinstalling.
+func runFullPluginRefresh(claudeDir, syncDir string, quiet bool, skipKeys map[string]bool) (updated, failed []string) {
+	result, err := updateCheck(claudeDir, syncDir)
+	if err != nil || !result.hasUpdates() {
+		return nil, nil
+	}
+
+	var upstreamKeys []string
+	for _, p := range result.UpstreamPlugins {
+		if !skipKeys[p.Key] {
+			upstreamKeys = append(upstreamKeys, p.Key)
+		}
+	}
+	if len(upstreamKeys) > 0 {
+		installed, fail := updateApply(claudeDir, syncDir, upstreamKeys, quiet)
+		updated = append(updated, installed...)
+		failed = append(failed, fail...)
+	}
+
+	if len(result.ForkedPlugins) > 0 {
+		var forkNames []string
+		for _, f := range result.ForkedPlugins {
+			forkNames = append(forkNames, f.Name)
+		}
+		installed, fail := updateForkedPlugins(claudeDir, syncDir, forkNames, quiet)
+		updated = append(updated, installed...)
+		failed = append(failed, fail...)
+	}
+
+	return updated, failed
+}
+
 // updateApply reinstalls the given upstream/pinned plugin keys.
 // It registers the local marketplace if forked plugins exist in the config.
 // Returns slices of successfully installed and failed plugin keys.

--- a/internal/commands/versioncheck.go
+++ b/internal/commands/versioncheck.go
@@ -17,20 +17,27 @@ const githubReleasesURL = "https://api.github.com/repos/ruminaider/claude-sync/r
 
 // isNewer returns true if latest is a newer semver than current.
 // Both must be in "major.minor.patch" format (no "v" prefix).
+// Returns false if either version string is malformed.
 func isNewer(latest, current string) bool {
-	parse := func(v string) (int, int, int) {
+	parse := func(v string) (int, int, int, bool) {
 		v = strings.TrimPrefix(v, "v")
 		parts := strings.SplitN(v, ".", 3)
 		if len(parts) != 3 {
-			return 0, 0, 0
+			return 0, 0, 0, false
 		}
-		major, _ := strconv.Atoi(parts[0])
-		minor, _ := strconv.Atoi(parts[1])
-		patch, _ := strconv.Atoi(parts[2])
-		return major, minor, patch
+		major, err1 := strconv.Atoi(parts[0])
+		minor, err2 := strconv.Atoi(parts[1])
+		patch, err3 := strconv.Atoi(parts[2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			return 0, 0, 0, false
+		}
+		return major, minor, patch, true
 	}
-	lMaj, lMin, lPat := parse(latest)
-	cMaj, cMin, cPat := parse(current)
+	lMaj, lMin, lPat, lok := parse(latest)
+	cMaj, cMin, cPat, cok := parse(current)
+	if !lok || !cok {
+		return false
+	}
 	if lMaj != cMaj {
 		return lMaj > cMaj
 	}

--- a/internal/commands/versioncheck_test.go
+++ b/internal/commands/versioncheck_test.go
@@ -18,6 +18,9 @@ func TestIsNewer(t *testing.T) {
 		{"0.11.0", "0.11.0", false},
 		{"0.10.0", "0.11.0", false},
 		{"0.11.0", "0.12.0", false},
+		{"garbage", "0.11.0", false},
+		{"0.11.0", "garbage", false},
+		{"abc.def.ghi", "0.11.0", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.latest+"_vs_"+tt.current, func(t *testing.T) {

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -46,7 +46,7 @@ if acquire_lock; then
     pull_ok=false
   fi
 
-  # Check for update notification in pull stderr.
+  # Protocol emitted by cmd/claude-sync/cmd_pull.go; keep in sync.
   UPDATE_LINE=$(echo "$PULL_ERR" | grep "^UPDATE_AVAILABLE:" || true)
   if [ -n "$UPDATE_LINE" ]; then
     CURRENT_VER=$(echo "$UPDATE_LINE" | cut -d: -f2)


### PR DESCRIPTION
## Summary

- Replace `renderMainScreen`'s 14 positional args (4 bare bools) with a `MainScreenParams` struct for readability and safe extensibility
- Embed `VersionCheckResult` in `PullResult` instead of duplicating three fields with manual assignment
- Extract `runFullPluginRefresh` helper into `update.go` with skip-key logic to avoid double-reinstalling plugins already refreshed by stale detection
- Derive Catppuccin Latte accent colors from the library (`catppuccin.Latte`) instead of hardcoded hex values
- Fix `isNewer` to explicitly reject malformed semver strings instead of silently treating `strconv.Atoi` errors as `0`
- Add cross-file "keep in sync" comments for the `UPDATE_AVAILABLE` protocol shared between `cmd_pull.go` and `session-start.sh`

## Test plan

- [x] All 20 Go packages pass (`go test ./... -count=1`)
- [x] New test cases for malformed semver input in `isNewer`
- [x] All existing dashboard render tests updated to use `MainScreenParams`